### PR TITLE
Endre senderId til string

### DIFF
--- a/Digipost.Api.Client.Domain/Message/Message.cs
+++ b/Digipost.Api.Client.Domain/Message/Message.cs
@@ -37,8 +37,8 @@ namespace Digipost.Api.Client.Domain
         /// <param name="recipient">The recipient receiving the message.</param>
         /// <param name="primaryDocument">The primary document sent to the recipient.</param>
         /// <param name="senderId">The id of the sender, created by Digipost.  If you are delivering a 
-        /// message on behalf of an organization, and permission to do so is set, this is the parameter to set. </param>
-        public Message(Recipient recipient, Document primaryDocument, long senderId):
+        /// message on behalf of an organization, and permission to do so is set, this is the parameter use. </param>
+        public Message(Recipient recipient, Document primaryDocument, string senderId):
             this(recipient, primaryDocument)
         {
             SenderValue = senderId;
@@ -61,7 +61,7 @@ namespace Digipost.Api.Client.Domain
         }
         
         [XmlChoiceIdentifier("SenderType")]
-        [XmlElement("sender-id", typeof(long))]
+        [XmlElement("sender-id", typeof(string))]
         [XmlElement("sender-organization", typeof(SenderOrganization))]
         public object SenderValue { get; set; }
 

--- a/Digipost.Api.Client.Tests/Unittest/SerializeUtilTests.cs
+++ b/Digipost.Api.Client.Tests/Unittest/SerializeUtilTests.cs
@@ -100,7 +100,7 @@ namespace Digipost.Api.Client.Tests.Unittest
                 var document = new Document("Subject", "txt", ByteUtility.GetBytes("test"), AuthenticationLevel.TwoFactor,
                     SensitivityLevel.Sensitive) { Guid = "1222222", SmsNotification = new SmsNotification(2) };
 
-                var messageTemplate = new Message(recipient, document, 1237732);
+                var messageTemplate = new Message(recipient, document, "1237732");
                 
                 //Act
                 var deserializedMessageBlueprint = SerializeUtil.Deserialize<Message>(messageBlueprint);
@@ -290,7 +290,7 @@ namespace Digipost.Api.Client.Tests.Unittest
                 var document = new Document("Subject", "txt", ByteUtility.GetBytes("test"), AuthenticationLevel.TwoFactor,
                     SensitivityLevel.Sensitive) { Guid = "1222222", SmsNotification = new SmsNotification(2) };
 
-                var messageTemplate = new Message(recipient, document, 1237732);
+                var messageTemplate = new Message(recipient, document, "1237732");
 
                 //Act
                 var serializedMessage = SerializeUtil.Serialize(messageTemplate);


### PR DESCRIPTION
For å være konsekvent på at id er av typen string, endres senderId på message til string.