### PR TITLE
Fjern .Result som fører til deadlock i DigipostApi

### DIFF
--- a/Digipost.Api.Client/Api/DigipostApi.cs
+++ b/Digipost.Api.Client/Api/DigipostApi.cs
@@ -132,7 +132,8 @@ namespace Digipost.Api.Client.Api
 
         private async Task<T> GenericSendAsync<T>(Task<HttpResponseMessage> responseTask)
         {
-            var responseTaskResult = responseTask.Result;
+            var responseTaskResult = await responseTask;
+
             var responseContent = await ReadResponse(responseTaskResult);
 
             if (!responseTaskResult.IsSuccessStatusCode)


### PR DESCRIPTION
Problemet med ASP.NET deadlocken kan i korte trekk forklares med at vi gjør .Result. For en mer inngående forklaring, så kan du spørre meg.