### PR TITLE
removes the use of ConsoleLogger as default. 

### DIFF
--- a/Digipost.Api.Client/ClientConfig.cs
+++ b/Digipost.Api.Client/ClientConfig.cs
@@ -49,7 +49,6 @@ namespace Digipost.Api.Client
             if (!string.IsNullOrEmpty(senderId))
                 _senderId = senderId;
 
-            Logger = Logging.ConsoleLogger();
             LogToFile = SetFromAppConfig("DP:LogToFile", Settings.Default.LogToFile);
             LogPath = SetFromAppConfig("DP:LogPath",
                 Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Digipost", "Rest",

--- a/Digipost.Api.Client/Logging.cs
+++ b/Digipost.Api.Client/Logging.cs
@@ -24,7 +24,7 @@ namespace Digipost.Api.Client
         {
             if (_logAction == null) 
             { 
-                _logAction = ConsoleLogger();
+                return;
             }
 
             if (callerMember == null) 

--- a/digipost-api-client.sln
+++ b/digipost-api-client.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Digipost.Api.Client.Domain", "Digipost.Api.Client.Domain\Digipost.Api.Client.Domain.csproj", "{6622E975-31E3-45DB-8156-FB593FC872F4}"
 EndProject


### PR DESCRIPTION
Console.WriteLine causes deadlock in some cases. By default the ConsoleLogger(which uses Console.writeline) is set in ClientConfig.initialization. 

In this "fix" the user must manually set LoggerAction if he/she wants to log. 