### PR TITLE
Removes user scoped settings

### DIFF
--- a/Digipost.Api.Client.Tests/Integration/DomainUtility.cs
+++ b/Digipost.Api.Client.Tests/Integration/DomainUtility.cs
@@ -13,6 +13,11 @@ namespace Digipost.Api.Client.Tests.Integration
     {
         private static readonly ResourceUtility ResourceUtility = new ResourceUtility("Digipost.Api.Client.Tests.Resources");
 
+        public static ClientConfig GetClientConfig()
+        {
+            return new ClientConfig("senderId");
+        }
+
         public static IMessage GetSimpleMessageWithRecipientById()
         {
             var message = new Message(

--- a/Digipost.Api.Client.Tests/Unittest/DigipostActionFactoryTests.cs
+++ b/Digipost.Api.Client.Tests/Unittest/DigipostActionFactoryTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Security.Cryptography.X509Certificates;
 using ApiClientShared;
 using Digipost.Api.Client.Action;
-using Digipost.Api.Client.Tests.Integration;
 using Xunit;
+using static Digipost.Api.Client.Tests.Integration.DomainUtility;
 
 namespace Digipost.Api.Client.Tests.Unittest
 {
@@ -22,10 +22,10 @@ namespace Digipost.Api.Client.Tests.Unittest
             {
                 //Arrange
                 var factory = new DigipostActionFactory();
-                var message = DomainUtility.GetSimpleMessageWithRecipientById();
+                var message = GetSimpleMessageWithRecipientById();
 
                 //Act
-                var action = factory.CreateClass(message, new ClientConfig(), new X509Certificate2(), "uri");
+                var action = factory.CreateClass(message, GetClientConfig(), new X509Certificate2(), "uri");
                 //Assert
 
                 Assert.Equal(typeof (MessageAction), action.GetType());
@@ -36,10 +36,10 @@ namespace Digipost.Api.Client.Tests.Unittest
             {
                 //Arrange
                 var factory = new DigipostActionFactory();
-                var identification = DomainUtility.GetPersonalIdentification();
+                var identification = GetPersonalIdentification();
 
                 //Act
-                var action = factory.CreateClass(identification, new ClientConfig(), new X509Certificate2(), "uri");
+                var action = factory.CreateClass(identification, GetClientConfig(), new X509Certificate2(), "uri");
 
                 //Assert
                 Assert.Equal(typeof (IdentificationAction), action.GetType());

--- a/Digipost.Api.Client/ClientConfig.cs
+++ b/Digipost.Api.Client/ClientConfig.cs
@@ -1,22 +1,13 @@
 ﻿using System;
-using System.Configuration;
 using System.Diagnostics;
-using System.IO;
-using Digipost.Api.Client.Domain.Exceptions;
-using Digipost.Api.Client.Properties;
 
 namespace Digipost.Api.Client
 {
     /// <summary>
-    ///     Contains configuration for sending digital post. Values can be overridden in App.config , using following format:
-    ///     'DP:Variable', where Variable is placeholder for variable name in this class. Changing the timeout
-    ///     (TimeoutMilliseconds)
-    ///     would result in the following in App.config: <![CDATA[<appSettings><add key="DP:TimeoutMilliseconds" value="10"/></appSettings> ]]>
+    ///     Contains configuration for sending digital post.
     /// </summary>
     public class ClientConfig
     {
-        private readonly string _senderId = string.Empty;
-
         /// <summary>
         ///     Client configuration used for setting up the client with settings.
         /// </summary>
@@ -29,35 +20,14 @@ namespace Digipost.Api.Client
         {
             ApiUrl = new Uri(apiUrl);
             TimeoutMilliseconds = timeoutInMilliseconds;
-            _senderId = senderId;
+            SenderId = senderId;
             LogToFile = logToFile;
             LogPath = logPath;
         }
 
         /// <summary>
-        ///     Client configuration used for setting up the client with settings.
-        /// </summary>
-        /// <param name="senderId">Defines the id of the sender. If you do not set it here, use App.config. </param>
-        public ClientConfig(string senderId = "")
-        {
-            ApiUrl = SetFromAppConfig("DP:Url", new Uri(Settings.Default.Url));
-            TimeoutMilliseconds = SetFromAppConfig("DP:TimeoutMilliseconds", Settings.Default.TimeoutMilliseconds);
-
-            _senderId = SetFromAppConfig("DP:SenderId", Settings.Default.SenderId);
-
-            if (!string.IsNullOrEmpty(senderId))
-                _senderId = senderId;
-
-            LogToFile = SetFromAppConfig("DP:LogToFile", Settings.Default.LogToFile);
-            LogPath = SetFromAppConfig("DP:LogPath",
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Digipost", "Rest",
-                    "Log"));
-        }
-
-        /// <summary>
         ///     Defines Uri to be used for sending messages. Default value is 'https://api.digipost.no/'. Defines Url to be used
         ///     for message delivery.
-        ///     This value can be overridden in the application configuration file with key 'DP:Url' in appSettings.
         /// </summary>
         /// <remarks>
         ///     Url for QA is 'https://qa.api.digipost.no/'.
@@ -65,10 +35,7 @@ namespace Digipost.Api.Client
         public Uri ApiUrl { get; set; }
 
         /// <summary>
-        ///     Defines the timeout for communication with Digipost API. Default is 30 seconds. This
-        ///     Angir timeout for komunikasjonen fra og til meldingsformindleren. Default tid er 30 sekunder.
-        ///     This value can be overridden in the application configuration file with key 'DP:TimeoutMilliseconds' in
-        ///     appSettings.
+        ///     Defines the timeout for communication with Digipost API. Default is 30 seconds.
         /// </summary>
         public int TimeoutMilliseconds { get; set; }
 
@@ -76,32 +43,18 @@ namespace Digipost.Api.Client
         ///     The identification of the technical sender of messages to Digipost. This value is obtained during registration of
         ///     sender.
         /// </summary>
-        public string SenderId
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_senderId))
-                {
-                    throw new ConfigException(
-                        "Technical sender id must be valid set to send messages. Set this by code on ClientConfig or in App.config under node" +
-                        "'appSettings' with key 'DP:SenderId' (<add key=\"DP:SenderId\" value=\"01234567\"/>)");
-                }
-
-                return _senderId;
-            }
-        }
+        public string SenderId { get; set; }
 
         /// <summary>
         ///     Exposes logging where you can integrate your own logger or third party logger (i.e. log4net). For use, set an
-        ///     anonymous function with
-        ///     the following parameters: conversationId, method, message. As a default, trace logging is enabled with
+        ///     anonymous function with the following parameters: conversationId, method, message. As a default, trace logging is enabled with
         ///     'Digipost.Api.Client', which can be
         ///     activated in App.config.
         /// </summary>
         public Action<TraceEventType, Guid?, string, string> Logger { get; set; }
 
         /// <summary>
-        ///     Defines if logging is to be done for all messages between the client and Digipost
+        ///     Defines if logging is to be done for all messages between the client and Digipost.
         /// </summary>
         public bool LogToFile { get; set; }
 
@@ -111,20 +64,5 @@ namespace Digipost.Api.Client
         /// </summary>
         public string LogPath { get; set; }
 
-        private T SetFromAppConfig<T>(string key, T @default)
-        {
-            var appSettings = ConfigurationManager.AppSettings;
-
-            var value = appSettings[key];
-            if (value == null)
-                return @default;
-
-            if (typeof (IConvertible).IsAssignableFrom(typeof (T)))
-            {
-                return (T) Convert.ChangeType(value, typeof (T));
-            }
-
-            return (T) Activator.CreateInstance(typeof (T), value);
-        }
     }
 }


### PR DESCRIPTION
The simple reason is that it cannot be supported in a client library. It will be ignored by the app using the library