### PR TITLE
Adds Environment as class

### DIFF
--- a/Digipost.Api.Client.ConcurrencyTest/Initializer.cs
+++ b/Digipost.Api.Client.ConcurrencyTest/Initializer.cs
@@ -7,7 +7,6 @@ namespace Digipost.Api.Client.ConcurrencyTest
     {
         private const ProcessingType ProcessingType = Enums.ProcessingType.Parallel;
         private const RequestType RequestType = Enums.RequestType.Message;
-        private const string HttpsQa2ApiDigipostNo = "https://qa2.api.digipost.no";
         private const string Thumbprint = "29 7e 44 24 f2 8d ed 2c 9a a7 3d 9b 22 7c 73 48 f1 8a 1b 9b";
         private const string SenderId = "106824802"; //"779052"; 
         private const int DegreeOfParallelism = 4;
@@ -25,9 +24,8 @@ namespace Digipost.Api.Client.ConcurrencyTest
             Console.WriteLine("Starting to send digipost: {0}, with requests: {1}, poolcount: {2}", processingType,
                 numberOfRequests, connectionLimit);
 
-            var clientConfig = new ClientConfig(SenderId)
+            var clientConfig = new ClientConfig(SenderId, Environment.Qa)
             {
-                ApiUrl = new Uri(HttpsQa2ApiDigipostNo),
                 Logger = (severity, konversasjonsId, metode, melding) => { }
             };
 

--- a/Digipost.Api.Client.Test/Action/DigipostActionFactoryTests.cs
+++ b/Digipost.Api.Client.Test/Action/DigipostActionFactoryTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography.X509Certificates;
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using ApiClientShared;
 using Digipost.Api.Client.Action;
 using Xunit;
@@ -24,7 +25,7 @@ namespace Digipost.Api.Client.Test.Action
                 var message = DomainUtility.GetSimpleMessageWithRecipientById();
 
                 //Act
-                var action = factory.CreateClass(message, DomainUtility.GetClientConfig(), new X509Certificate2(), "uri");
+                var action = factory.CreateClass(message, DomainUtility.GetClientConfig(), new X509Certificate2(), new Uri("/fakeuri", UriKind.Relative));
                 //Assert
 
                 Assert.Equal(typeof (MessageAction), action.GetType());
@@ -38,7 +39,7 @@ namespace Digipost.Api.Client.Test.Action
                 var identification = DomainUtility.GetPersonalIdentification();
 
                 //Act
-                var action = factory.CreateClass(identification, DomainUtility.GetClientConfig(), new X509Certificate2(), "uri");
+                var action = factory.CreateClass(identification, DomainUtility.GetClientConfig(), new X509Certificate2(), new Uri("/fakeuri", UriKind.Relative));
 
                 //Assert
                 Assert.Equal(typeof (IdentificationAction), action.GetType());

--- a/Digipost.Api.Client.Test/Action/DigipostActionTests.cs
+++ b/Digipost.Api.Client.Test/Action/DigipostActionTests.cs
@@ -1,4 +1,5 @@
-﻿using ApiClientShared;
+﻿using System;
+using ApiClientShared;
 using Digipost.Api.Client.Action;
 using Digipost.Api.Client.Domain.Enums;
 using Digipost.Api.Client.Domain.Identify;
@@ -23,9 +24,9 @@ namespace Digipost.Api.Client.Test.Action
             public void ReturnsCorrectDataForMessage()
             {
                 //Arrange
-                var clientConfig = new ClientConfig("123");
+                var clientConfig = new ClientConfig("123", Environment.Qa);
                 var certificate = TestProperties.Certificate();
-                const string uri = "AFakeUri";
+                Uri uri = new Uri("http://fakeuri.no");
                 var message = DomainUtility.GetSimpleMessageWithRecipientById();
 
                 //Act
@@ -41,9 +42,9 @@ namespace Digipost.Api.Client.Test.Action
             public void ReturnsCorrectDataForIdentification()
             {
                 //Arrange
-                var clientConfig = new ClientConfig("123");
+                var clientConfig = new ClientConfig("123", Environment.Qa);
                 var certificate = TestProperties.Certificate();
-                const string uri = "AFakeUri";
+                Uri uri = new Uri("http://fakeuri.no");
                 var identification = new Identification(new RecipientById(IdentificationType.PersonalIdentificationNumber, "00000000000"));
 
                 //Act

--- a/Digipost.Api.Client.Test/Digipost.Api.Client.Test.csproj
+++ b/Digipost.Api.Client.Test/Digipost.Api.Client.Test.csproj
@@ -90,6 +90,7 @@
     <Compile Include="CompareObjects\Difference.cs" />
     <Compile Include="CompareObjects\IComparator.cs" />
     <Compile Include="CompareObjects\IDifference.cs" />
+    <Compile Include="EnvironmentTests.cs" />
     <Compile Include="Fakes\FakeDocument.cs" />
     <Compile Include="Fakes\FakeHttpClientHandlerForIdentificationResponse.cs" />
     <Compile Include="Fakes\FakeHttpClientHandlerForMessageResponse.cs" />

--- a/Digipost.Api.Client.Test/DomainUtility.cs
+++ b/Digipost.Api.Client.Test/DomainUtility.cs
@@ -15,7 +15,7 @@ namespace Digipost.Api.Client.Test
 
         public static ClientConfig GetClientConfig()
         {
-            return new ClientConfig("senderId");
+            return new ClientConfig("senderId", Environment.Qa);
         }
 
         public static IMessage GetSimpleMessageWithRecipientById()

--- a/Digipost.Api.Client.Test/EnvironmentTests.cs
+++ b/Digipost.Api.Client.Test/EnvironmentTests.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Xunit;
+
+namespace Digipost.Api.Client.Test
+{
+    public class EnvironmentTests
+    {
+        [Fact]
+        public void Can_Change_Url()
+        {
+            Environment env = Environment.Preprod; ;
+            env.Url = new Uri("http://api.newenvironment.digipost.no");
+        }
+    }
+}

--- a/Digipost.Api.Client.Test/Integration/DigipostApiIntegrationTests.cs
+++ b/Digipost.Api.Client.Test/Integration/DigipostApiIntegrationTests.cs
@@ -20,16 +20,16 @@ namespace Digipost.Api.Client.Test.Integration
     {
         protected X509Certificate2 Certificate;
         protected ClientConfig ClientConfig;
-        protected string Uri;
+        protected Uri Uri;
 
         public DigipostApiIntegrationTests()
         {
-            ClientConfig = new ClientConfig("1337")
+            ClientConfig = new ClientConfig("1337", Environment.Qa)
             {
                 LogRequestAndResponse = false,
                 TimeoutMilliseconds = 300000000
             };
-            Uri = "identification";
+            Uri = new Uri("/identification", UriKind.Relative);
             Certificate = TestProperties.Certificate();
         }
 
@@ -153,7 +153,7 @@ namespace Digipost.Api.Client.Test.Integration
                 mockFacktory.Setup(
                     f =>
                         f.CreateClass(message, It.IsAny<ClientConfig>(), It.IsAny<X509Certificate2>(),
-                            It.IsAny<string>()))
+                            It.IsAny<Uri>()))
                     .Returns(new MessageAction(message, ClientConfig, Certificate, Uri)
                     {
                         HttpClient = new HttpClient(authenticationHandler) {BaseAddress = new Uri("http://tull")}
@@ -216,7 +216,7 @@ namespace Digipost.Api.Client.Test.Integration
                 mockFactory.Setup(
                     f =>
                         f.CreateClass(identification, It.IsAny<ClientConfig>(), It.IsAny<X509Certificate2>(),
-                            It.IsAny<string>()))
+                            It.IsAny<Uri>()))
                     .Returns(new IdentificationAction(identification, ClientConfig, Certificate, Uri)
                     {
                         HttpClient =
@@ -256,7 +256,7 @@ namespace Digipost.Api.Client.Test.Integration
                 mockFacktory.Setup(
                     f =>
                         f.CreateClass(It.IsAny<ClientConfig>(), It.IsAny<X509Certificate2>(),
-                            It.IsAny<string>()))
+                            It.IsAny<Uri>()))
                     .Returns(new GetByUriAction(null, ClientConfig, Certificate, Uri)
                     {
                         HttpClient =

--- a/Digipost.Api.Client.Test/Smoke/ClientSmokeTests.cs
+++ b/Digipost.Api.Client.Test/Smoke/ClientSmokeTests.cs
@@ -10,7 +10,7 @@ namespace Digipost.Api.Client.Test.Smoke
 
         public ClientSmokeTests()
         {
-            var sender = SenderUtility.GetSender(Environment.DifiTest);
+            var sender = SenderUtility.GetSender(TestEnvironment.DifiTest);
             _t = new TestHelper(sender);
         }
 

--- a/Digipost.Api.Client.Test/Smoke/TestHelper.cs
+++ b/Digipost.Api.Client.Test/Smoke/TestHelper.cs
@@ -7,7 +7,6 @@ using Digipost.Api.Client.Domain.Search;
 using Digipost.Api.Client.Domain.SendMessage;
 using Digipost.Api.Client.Test.Utilities;
 using Xunit;
-using Environment = System.Environment;
 
 namespace Digipost.Api.Client.Test.Smoke
 {
@@ -38,12 +37,12 @@ namespace Digipost.Api.Client.Test.Smoke
         private Sender OverrideSenderIfOnBuildServer(Sender sender)
         {
             const string buildServerUser = "administrator";
-            var currentUser = Environment.UserName.ToLower();
+            var currentUser = System.Environment.UserName.ToLower();
             var isCurrentUserBuildServer = currentUser.Contains(buildServerUser);
 
             if (isCurrentUserBuildServer)
             {
-                return SenderUtility.GetSender(Utilities.Environment.DifiTest);
+                return SenderUtility.GetSender(Utilities.TestEnvironment.DifiTest);
             }
 
             return sender;

--- a/Digipost.Api.Client.Test/Utilities/SenderUtility.cs
+++ b/Digipost.Api.Client.Test/Utilities/SenderUtility.cs
@@ -7,29 +7,31 @@ namespace Digipost.Api.Client.Test.Utilities
 {
     internal class SenderUtility
     {
-        public static Sender GetSender(Environment environment)
+        public static Sender GetSender(TestEnvironment testEnvironment)
         {
-            switch (environment)
+            var digipostTestintegrasjonforDigitalPostThumbprint = "‎2d 7f 30 dd 05 d3 b7 fc 7a e5 97 3a 73 f8 49 08 3b 20 40 ed";
+
+            switch (testEnvironment)
             {
-                case Environment.DifiTest:
+                case TestEnvironment.DifiTest:
                     return new Sender(
                         "497013",
-                        "‎2d 7f 30 dd 05 d3 b7 fc 7a e5 97 3a 73 f8 49 08 3b 20 40 ed", //Digipost Testintegrasjon for Digital Post
-                        "https://qaoffentlig.api.digipost.no/"
+                        digipostTestintegrasjonforDigitalPostThumbprint, 
+                        Environment.Preprod
                         );
-                case Environment.Qa:
+                case TestEnvironment.Qa:
                     return new Sender(
                         "2121714811",
-                        "‎2d 7f 30 dd 05 d3 b7 fc 7a e5 97 3a 73 f8 49 08 3b 20 40 ed", 
-                        "https://qa.api.digipost.no/"
+                        digipostTestintegrasjonforDigitalPostThumbprint, 
+                        Environment.Qa
                         );
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(environment), environment, null);
+                    throw new ArgumentOutOfRangeException(nameof(testEnvironment), testEnvironment, null);
             }
         }
     }
 
-    internal enum Environment
+    internal enum TestEnvironment
     {
         DifiTest,
         Qa
@@ -37,7 +39,7 @@ namespace Digipost.Api.Client.Test.Utilities
 
     internal class Sender
     {
-        public Sender(string id, string certificateThumbprint, string environment)
+        public Sender(string id, string certificateThumbprint, Environment environment)
         {
             Id = id;
             Certificate = CertificateUtility.SenderCertificate(certificateThumbprint, Language.English);
@@ -46,7 +48,7 @@ namespace Digipost.Api.Client.Test.Utilities
 
         public string Id { get; set; }
 
-        public string Environment { get; set; }
+        public Environment Environment { get; set; }
 
         public X509Certificate2 Certificate { get; set; }
     }

--- a/Digipost.Api.Client.Testklient/Program.cs
+++ b/Digipost.Api.Client.Testklient/Program.cs
@@ -31,9 +31,8 @@ namespace Digipost.Api.Client.Testklient
 
         private static void RunSingle()
         {
-            var config = new ClientConfig(SenderId)
+            var config = new ClientConfig(SenderId, Environment.Qa)
             {
-                ApiUrl = new Uri(Url),
                 Logger = (severity, konversasjonsId, metode, melding) =>
                 {
                     Console.WriteLine("{0}",

--- a/Digipost.Api.Client/Action/DigipostAction.cs
+++ b/Digipost.Api.Client/Action/DigipostAction.cs
@@ -10,7 +10,7 @@ namespace Digipost.Api.Client.Action
 {
     public abstract class DigipostAction
     {
-        protected DigipostAction(IRequestContent requestContent, ClientConfig clientConfig, X509Certificate2 businessCertificate, string uri)
+        protected DigipostAction(IRequestContent requestContent, ClientConfig clientConfig, X509Certificate2 businessCertificate, Uri uri)
         {
             InitializeRequestXmlContent(requestContent);
             Uri = uri;
@@ -19,7 +19,7 @@ namespace Digipost.Api.Client.Action
             HttpClient = GetHttpClient();
         }
 
-        private string Uri { get; }
+        private Uri Uri { get; }
 
         public ClientConfig ClientConfig { get; set; }
 
@@ -38,7 +38,7 @@ namespace Digipost.Api.Client.Action
             var httpClient = new HttpClient(authenticationHandler)
             {
                 Timeout = TimeSpan.FromMilliseconds(ClientConfig.TimeoutMilliseconds),
-                BaseAddress = new Uri(ClientConfig.ApiUrl.AbsoluteUri)
+                BaseAddress = new Uri(ClientConfig.Environment.Url.AbsoluteUri)
             };
 
             return httpClient;
@@ -51,7 +51,7 @@ namespace Digipost.Api.Client.Action
 
         internal Task<HttpResponseMessage> GetAsync()
         {
-            return HttpClient.GetAsync(Uri);
+            return HttpClient.GetAsync(Uri.ToString());
         }
 
         protected abstract HttpContent Content(IRequestContent requestContent);

--- a/Digipost.Api.Client/Action/DigipostActionFactory.cs
+++ b/Digipost.Api.Client/Action/DigipostActionFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography.X509Certificates;
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using Digipost.Api.Client.Domain;
 using Digipost.Api.Client.Domain.Exceptions;
 using Digipost.Api.Client.Domain.Identify;
@@ -9,7 +10,7 @@ namespace Digipost.Api.Client.Action
     internal class DigipostActionFactory : IDigipostActionFactory
     {
         public virtual DigipostAction CreateClass(IRequestContent content, ClientConfig clientConfig,
-            X509Certificate2 businessCertificate, string uri)
+            X509Certificate2 businessCertificate, Uri uri)
         {
             var type = content.GetType();
 
@@ -27,7 +28,7 @@ namespace Digipost.Api.Client.Action
         }
 
         public virtual DigipostAction CreateClass(ClientConfig clientConfig, X509Certificate2 businessCertificate,
-            string uri)
+            Uri uri)
         {
             return new GetByUriAction(null, clientConfig, businessCertificate, uri);
         }

--- a/Digipost.Api.Client/Action/GetByUriAction.cs
+++ b/Digipost.Api.Client/Action/GetByUriAction.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using Digipost.Api.Client.Domain;
 
@@ -6,7 +7,7 @@ namespace Digipost.Api.Client.Action
 {
     internal class GetByUriAction : DigipostAction
     {
-        public GetByUriAction(IRequestContent requestContent, ClientConfig clientConfig, X509Certificate2 businessCertificate, string uri)
+        public GetByUriAction(IRequestContent requestContent, ClientConfig clientConfig, X509Certificate2 businessCertificate, Uri uri)
             : base(requestContent, clientConfig, businessCertificate, uri)
         {
         }

--- a/Digipost.Api.Client/Action/IDigipostActionFactory.cs
+++ b/Digipost.Api.Client/Action/IDigipostActionFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography.X509Certificates;
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using Digipost.Api.Client.Domain;
 
 namespace Digipost.Api.Client.Action
@@ -6,9 +7,9 @@ namespace Digipost.Api.Client.Action
     internal interface IDigipostActionFactory
     {
         DigipostAction CreateClass(IRequestContent requestContent, ClientConfig clientConfig, X509Certificate2 businessCertificate,
-            string uri);
+            Uri uri);
 
         DigipostAction CreateClass(ClientConfig clientConfig, X509Certificate2 businessCertificate,
-            string uri);
+            Uri uri);
     }
 }

--- a/Digipost.Api.Client/Action/IdentificationAction.cs
+++ b/Digipost.Api.Client/Action/IdentificationAction.cs
@@ -10,7 +10,7 @@ namespace Digipost.Api.Client.Action
 {
     internal class IdentificationAction : DigipostAction
     {
-        public IdentificationAction(IIdentification identification, ClientConfig clientConfig, X509Certificate2 businessCertificate, string uri)
+        public IdentificationAction(IIdentification identification, ClientConfig clientConfig, X509Certificate2 businessCertificate, Uri uri)
             : base(identification, clientConfig, businessCertificate, uri)
         {
         }

--- a/Digipost.Api.Client/Action/MessageAction.cs
+++ b/Digipost.Api.Client/Action/MessageAction.cs
@@ -10,7 +10,7 @@ namespace Digipost.Api.Client.Action
 {
     internal class MessageAction : DigipostAction
     {
-        public MessageAction(IMessage message, ClientConfig clientConfig, X509Certificate2 businessCertificate, string uri)
+        public MessageAction(IMessage message, ClientConfig clientConfig, X509Certificate2 businessCertificate, Uri uri)
             : base(message, clientConfig, businessCertificate, uri)
         {
         }

--- a/Digipost.Api.Client/Api/DigipostApi.cs
+++ b/Digipost.Api.Client/Api/DigipostApi.cs
@@ -65,7 +65,7 @@ namespace Digipost.Api.Client.Api
         {
             Log.Debug($"Outgoing Digipost message to Recipient: {message.DigipostRecipient}");
 
-            const string uri = "messages";
+            var uri = new Uri("messages", UriKind.Relative);
 
             var messageDeliveryResultTask = GenericPostAsync<MessageDeliveryResultDataTransferObject>(message, uri);
 
@@ -88,7 +88,7 @@ namespace Digipost.Api.Client.Api
         {
             Log.Debug($"Outgoing identification request: {identification}");
 
-            const string uri = "identification";
+            var uri = new Uri("identification", UriKind.Relative);
 
             var identifyResponse = GenericPostAsync<IdentificationResultDataTransferObject>(identification, uri);
 
@@ -120,7 +120,7 @@ namespace Digipost.Api.Client.Api
             Log.Debug($"Outgoing search request, term: '{search}'.");
 
             search = search.RemoveReservedUriCharacters();
-            var uri = string.Format("recipients/search/{0}", Uri.EscapeUriString(search));
+            var uri = new Uri($"recipients/search/{Uri.EscapeUriString(search)}", UriKind.Relative);
 
             if (search.Length < _minimumSearchLength)
             {
@@ -139,7 +139,7 @@ namespace Digipost.Api.Client.Api
             return searchDetailsResult;
         }
 
-        private Task<T> GenericPostAsync<T>(IRequestContent content, string uri)
+        private Task<T> GenericPostAsync<T>(IRequestContent content, Uri uri)
         {
             var action = DigipostActionFactory.CreateClass(content, ClientConfig, BusinessCertificate, uri);
 
@@ -149,7 +149,7 @@ namespace Digipost.Api.Client.Api
             return GenericSendAsync<T>(responseTask);
         }
 
-        private Task<T> GenericGetAsync<T>(string uri)
+        private Task<T> GenericGetAsync<T>(Uri uri)
         {
             var action = DigipostActionFactory.CreateClass(ClientConfig, BusinessCertificate, uri);
             var responseTask = action.GetAsync();

--- a/Digipost.Api.Client/ClientConfig.cs
+++ b/Digipost.Api.Client/ClientConfig.cs
@@ -16,13 +16,11 @@ namespace Digipost.Api.Client
         /// <param name="timeoutInMilliseconds">Timeout intervall for requests made to Digipost, default 30000</param>
         /// <param name="logToFile">Log to file, default false</param>
         /// <param name="logPath">Path to where the logfile wil be placed. Default blank</param>
-        public ClientConfig(string senderId, string apiUrl = "https://api.digipost.no/", int timeoutInMilliseconds = 30000, bool logToFile = false, string logPath = "")
+        public ClientConfig(string senderId, Environment environment, int timeoutInMilliseconds = 30000)
         {
-            ApiUrl = new Uri(apiUrl);
+            Environment = environment;
             TimeoutMilliseconds = timeoutInMilliseconds;
             SenderId = senderId;
-            LogToFile = logToFile;
-            LogPath = logPath;
         }
 
         /// <summary>
@@ -32,7 +30,7 @@ namespace Digipost.Api.Client
         /// <remarks>
         ///     Url for QA is 'https://qa.api.digipost.no/'.
         /// </remarks>
-        public Uri ApiUrl { get; set; }
+        public Environment Environment { get; set; }
 
         /// <summary>
         ///     Defines the timeout for communication with Digipost API. Default is 30 seconds.

--- a/Digipost.Api.Client/Digipost.Api.Client.csproj
+++ b/Digipost.Api.Client/Digipost.Api.Client.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Action\IDigipostActionFactory.cs" />
     <Compile Include="DigipostClient.cs" />
     <Compile Include="Api\IDigipostApi.cs" />
+    <Compile Include="Environment.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Handlers\AuthenticationHandler.cs" />
     <Compile Include="ClientConfig.cs" />

--- a/Digipost.Api.Client/Environment.cs
+++ b/Digipost.Api.Client/Environment.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Digipost.Api.Client
+{
+
+    public class Environment
+    {
+        private Environment(Uri url)
+        {
+            Url = url;
+        }
+
+        public Uri Url { get; set; }
+
+        public override string ToString()
+        {
+            return $"Url: {Url}";
+        }
+
+        public static Environment Production => new Environment(new Uri("https://api.digipost.no/"));
+
+        public static Environment Test => new Environment(new Uri("https://api.test.digipost.no/"));
+
+        public static Environment Qa => new Environment(new Uri("https://qa.api.digipost.no/"));
+
+        public static Environment Preprod => new Environment(new Uri("https://qaoffentlig.api.digipost.no/"));
+    }
+
+}

--- a/Digipost.Api.Client/Handlers/AuthenticationHandler.cs
+++ b/Digipost.Api.Client/Handlers/AuthenticationHandler.cs
@@ -17,7 +17,7 @@ namespace Digipost.Api.Client.Handlers
     {
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-        public AuthenticationHandler(ClientConfig clientConfig, X509Certificate2 businessCertificate, string url,
+        public AuthenticationHandler(ClientConfig clientConfig, X509Certificate2 businessCertificate, Uri url,
             HttpMessageHandler innerHandler)
             : base(innerHandler)
         {
@@ -29,7 +29,7 @@ namespace Digipost.Api.Client.Handlers
 
         private ClientConfig ClientConfig { get; }
 
-        private string Url { get; }
+        private Uri Url { get; }
 
         private X509Certificate2 BusinessCertificate { get; }
 
@@ -56,7 +56,7 @@ namespace Digipost.Api.Client.Handlers
                 request.Headers.Add("X-Content-SHA256", contentHash);
             }
 
-            var signature = ComputeSignature(Method, Url, date, contentHash, senderId, BusinessCertificate, ClientConfig.LogRequestAndResponse);
+            var signature = ComputeSignature(Method, Url.ToString(), date, contentHash, senderId, BusinessCertificate, ClientConfig.LogRequestAndResponse);
             request.Headers.Add("X-Digipost-Signature", signature);
 
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
The client configuration now utilize an Environment class, easing the change of environment. Sending urls as string throughout the application is unfortunate. This is now fixed. Having the API url as an optional is a terrible idea, as the user should be aware of what environment he/she use.