### PR TITLE
Proposal for #180 CancellationToken Support

### DIFF
--- a/Digipost.Api.Client.Common/Utilities/RequestHelper.cs
+++ b/Digipost.Api.Client.Common/Utilities/RequestHelper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Digipost.Api.Client.Common.Exceptions;
@@ -22,28 +23,28 @@ namespace Digipost.Api.Client.Common.Utilities
 
         internal HttpClient HttpClient { get; set; }
 
-        internal Task<T> Post<T>(HttpContent httpContent, XmlDocument messageActionRequestContent, Uri uri, bool skipMetaDataValidation = false)
+        internal Task<T> Post<T>(HttpContent httpContent, XmlDocument messageActionRequestContent, Uri uri, bool skipMetaDataValidation = false,CancellationToken cancellationToken=default)
         {
             ValidateXml(messageActionRequestContent, skipMetaDataValidation);
 
-            var postAsync = HttpClient.PostAsync(uri, httpContent);
+            var postAsync = HttpClient.PostAsync(uri, httpContent,cancellationToken);
 
             return Send<T>(postAsync);
         }
 
-        internal Task<T> Get<T>(Uri uri)
+        internal Task<T> Get<T>(Uri uri,CancellationToken cancellationToken=default)
         {
-            return Send<T>(HttpClient.GetAsync(uri));
+            return Send<T>(HttpClient.GetAsync(uri,cancellationToken));
         }
 
-        internal Task<string> Delete(Uri uri)
+        internal Task<string> Delete(Uri uri,CancellationToken cancellationToken=default)
         {
-            return Send<string>(HttpClient.DeleteAsync(uri));
+            return Send<string>(HttpClient.DeleteAsync(uri,cancellationToken));
         }
 
-        internal async Task<Stream> GetStream(Uri uri)
+        internal async Task<Stream> GetStream(Uri uri,CancellationToken cancellationToken=default)
         {
-            var responseTask = HttpClient.GetAsync(uri);
+            var responseTask = HttpClient.GetAsync(uri,cancellationToken);
             var httpResponseMessage = await responseTask.ConfigureAwait(false);
 
             if (!httpResponseMessage.IsSuccessStatusCode)

--- a/Digipost.Api.Client.Send/SendRequestHelper.cs
+++ b/Digipost.Api.Client.Send/SendRequestHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Digipost.Api.Client.Common.Actions;
 using Digipost.Api.Client.Common.Identify;
@@ -20,20 +21,20 @@ namespace Digipost.Api.Client.Send
             return _requestHelper.Get<T>(uri);
         }
 
-        internal Task<T> PostMessage<T>(IMessage message, Uri uri, bool skipMetaDataValidation = false)
+        internal Task<T> PostMessage<T>(IMessage message, Uri uri, bool skipMetaDataValidation = false,CancellationToken cancellationToken=default)
         {
             var messageAction = new MessageAction(message);
             var httpContent = messageAction.Content(message);
 
-            return _requestHelper.Post<T>(httpContent, messageAction.RequestContent, uri, skipMetaDataValidation);
+            return _requestHelper.Post<T>(httpContent, messageAction.RequestContent, uri, skipMetaDataValidation,cancellationToken);
         }
 
-        internal Task<T> PostIdentification<T>(IIdentification identification, Uri uri)
+        internal Task<T> PostIdentification<T>(IIdentification identification, Uri uri,CancellationToken cancellationToken=default)
         {
             var messageAction = new IdentificationAction(identification);
             var httpContent = messageAction.Content(identification);
 
-            return _requestHelper.Post<T>(httpContent, messageAction.RequestContent, uri);
+            return _requestHelper.Post<T>(httpContent, messageAction.RequestContent, uri,false,cancellationToken);
         }
     }
 }

--- a/Digipost.Api.Client/Api/SendMessage.cs
+++ b/Digipost.Api.Client/Api/SendMessage.cs
@@ -99,6 +99,31 @@ namespace Digipost.Api.Client.Api
 
             return identificationResult;
         }
+        public async Task<IIdentificationResult> IdentifyAsync(IIdentification identification,CancellationToken cancellationToken)
+        {
+            _logger.LogDebug($"Outgoing identification request: {identification}");
+
+            var uri = new Uri("identification", UriKind.Relative);
+
+            var identifyResponse = RequestHelper.PostIdentification<V7.Identification_Result>(identification, uri,cancellationToken);
+
+            if (identifyResponse.IsFaulted)
+            {
+                var exception = identifyResponse.Exception?.InnerException;
+
+                _logger.LogWarning($"Identification failed, {exception}");
+
+                if (identifyResponse.Exception != null)
+                    throw identifyResponse.Exception.InnerException;
+            }
+
+            var identificationResultDataTransferObject = await identifyResponse.ConfigureAwait(false);
+            var identificationResult = DataTransferObjectConverter.FromDataTransferObject(identificationResultDataTransferObject);
+
+            _logger.LogDebug($"Response received for identification to recipient, ResultType '{identificationResult.ResultType}', Data '{identificationResult.Data}'.");
+
+            return identificationResult;
+        }
 
         public ISearchDetailsResult Search(string search)
         {

--- a/Digipost.Api.Client/DigipostClient.cs
+++ b/Digipost.Api.Client/DigipostClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using Digipost.Api.Client.Api;
 using Digipost.Api.Client.Common;
@@ -85,6 +86,10 @@ namespace Digipost.Api.Client
         {
             return _api.IdentifyAsync(identification);
         }
+        public Task<IIdentificationResult> IdentifyAsync(IIdentification identification,CancellationToken cancellationToken)
+        {
+            return _api.IdentifyAsync(identification,cancellationToken);
+        }
 
         public IMessageDeliveryResult SendMessage(IMessage message)
         {
@@ -94,6 +99,10 @@ namespace Digipost.Api.Client
         public Task<IMessageDeliveryResult> SendMessageAsync(IMessage message)
         {
             return _api.SendMessageAsync(message, _clientConfig.SkipMetaDataValidation);
+        }
+        public Task<IMessageDeliveryResult> SendMessageAsync(IMessage message,CancellationToken cancellationToken)
+        {
+            return _api.SendMessageAsync(message, _clientConfig.SkipMetaDataValidation,cancellationToken);
         }
 
         public ISearchDetailsResult Search(string query)


### PR DESCRIPTION
I tried to minimized the changes, and as such I created an optional parameter with default value on internal methods.
On public facing calls I had to create overloads to preserve backwards compatiblity on API surface.

I did not see any tests on this async path, so I have not created one, but there should be coverage on such public methods.