### PR TITLE
Fix bug where we expected wrong type from api

### DIFF
--- a/Digipost.Api.Client.Archive.Tests/Smoke/ArchiveSmokeTestsHelper.cs
+++ b/Digipost.Api.Client.Archive.Tests/Smoke/ArchiveSmokeTestsHelper.cs
@@ -146,14 +146,17 @@ ___/ / /  / / /_/ / /| |/ /___  / / / /___ ___/ // /
         public ArchiveSmokeTestsHelper ArchiveAFile(string archiveName = null)
         {
             string content = $"Smoketested with .net api client on {DateTime.Now.ToString(CultureInfo.CurrentCulture)}";
+            var newGuid = Guid.NewGuid();
+
             var withArchiveDocument = new Archive(new Sender(_testSender.Id), archiveName)
                 .WithArchiveDocument(
-                    new ArchiveDocument(Guid.NewGuid(), "smoketest.txt", "txt", "text/plain", FileContentBytes(content))
+                    new ArchiveDocument(newGuid, "smoketest.txt", "txt", "text/plain", FileContentBytes(content))
                         .WithAttribute("smoke", "test")
                 );
 
             _archive = _archiveApi.ArchiveDocuments(withArchiveDocument).Result;
 
+            var archiveDocument = _archiveApi.FetchDocumentFromExternalId(newGuid).Result;
             Assert.NotEmpty(_archive.ArchiveDocuments);
 
             return this;

--- a/Digipost.Api.Client.Archive/ArchiveApi.cs
+++ b/Digipost.Api.Client.Archive/ArchiveApi.cs
@@ -39,9 +39,9 @@ namespace Digipost.Api.Client.Archive
          */
         Task<Archive> GetArchiveDocument(GetArchiveDocumentByUuidUri getArchiveDocumentUri);
 
-        Task<ArchiveDocument> FetchDocumentFromExternalId(String externalId);
+        Task<Archive> FetchDocumentFromExternalId(String externalId);
 
-        Task<ArchiveDocument> FetchDocumentFromExternalId(Guid externalIdGuid);
+        Task<Archive> FetchDocumentFromExternalId(Guid externalIdGuid);
 
         Task<Stream> StreamDocumentFromExternalId(String externalId);
 
@@ -148,15 +148,15 @@ namespace Digipost.Api.Client.Archive
             return result;
         }
 
-        public async Task<ArchiveDocument> FetchDocumentFromExternalId(string externalId)
+        public async Task<Archive> FetchDocumentFromExternalId(string externalId)
         {
-            var result = await _requestHelper.Get<Archive_Document>(_root.GetGetArchiveDocumentsByUuidUri(externalId)).ConfigureAwait(false);
+            var result = await _requestHelper.Get<V8.Archive>(_root.GetGetArchiveDocumentsByUuidUri(externalId)).ConfigureAwait(false);
             return ArchiveDataTransferObjectConverter.FromDataTransferObject(result);
         }
 
-        public async Task<ArchiveDocument> FetchDocumentFromExternalId(Guid externalIdGuid)
+        public async Task<Archive> FetchDocumentFromExternalId(Guid externalIdGuid)
         {
-            var result = await _requestHelper.Get<Archive_Document>(_root.GetGetArchiveDocumentsByUuidUri(externalIdGuid)).ConfigureAwait(false);
+            var result = await _requestHelper.Get<V8.Archive>(_root.GetGetArchiveDocumentsByUuidUri(externalIdGuid)).ConfigureAwait(false);
             return ArchiveDataTransferObjectConverter.FromDataTransferObject(result);
         }
 

--- a/Digipost.Api.Client.Docs/ArchiveExamples.cs
+++ b/Digipost.Api.Client.Docs/ArchiveExamples.cs
@@ -126,7 +126,7 @@ namespace Digipost.Api.Client.Docs
 
         private async void ChangeAttributesReferenceIdOnArchiveDocument()
         {
-            ArchiveDocument archiveDocument = await client.GetArchive(sender).FetchDocumentFromExternalId(Guid.Parse("10ff4c99-8560-4741-83f0-1093dc4deb1c"));
+            ArchiveDocument archiveDocument = (await client.GetArchive(sender).FetchDocumentFromExternalId(Guid.Parse("10ff4c99-8560-4741-83f0-1093dc4deb1c"))).One();
             archiveDocument.WithAttribute("newKey", "foobar")
                 .WithReferenceId("MyProcessId[No12341234]Done");
 

--- a/docs/_v14_0/4_archive.md
+++ b/docs/_v14_0/4_archive.md
@@ -142,10 +142,10 @@ You will get in return an instance of `Archive` which contains information on th
 and the actual document. From this you can fetch the actual document.
 
 ```csharp
-ArchiveDocument archiveDocument = await client.GetArchive(sender).FetchDocumentFromExternalId(Guid.Parse("10ff4c99-8560-4741-83f0-1093dc4deb1c"));
+ArchiveDocument archiveDocument = (await client.GetArchive(sender).FetchDocumentFromExternalId(Guid.Parse("10ff4c99-8560-4741-83f0-1093dc4deb1c"))).One();
 ```
 ```csharp
-ArchiveDocument archiveDocument = await client.GetArchive(sender).FetchDocumentFromExternalId("MyExternalId");
+Archive archive = await client.GetArchive(sender).FetchDocumentFromExternalId("MyExternalId");
 ```
 
 You can store your guid that you used at upload time to fetch by `Guid`.


### PR DESCRIPTION
Fetch by externalId returns document information in an archive so that you can see where the document lives.

* Added the case to the smoketest