### PR TITLE
Bypass issue with Newtonsoft.json

### DIFF
--- a/Digipost.Api.Client/CertificateReader.cs
+++ b/Digipost.Api.Client/CertificateReader.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Digipost.Api.Client
-{ 
+{
     public class CertificateReader
     {
         private readonly ILogger<CertificateReader> _logger;
@@ -14,6 +14,7 @@ namespace Digipost.Api.Client
         private CertificateReader(ILoggerFactory loggerFactory)
         {
             _logger = loggerFactory.CreateLogger<CertificateReader>();
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings { MaxDepth = 128 };
         }
 
         public static X509Certificate2 ReadCertificate()
@@ -27,7 +28,7 @@ namespace Digipost.Api.Client
             var certificateReader = new CertificateReader(loggerFactory);
             return certificateReader.ReadCertificatePrivate();
         }
-        
+
         X509Certificate2 ReadCertificatePrivate()
         {
             var pathToSecrets = $"{System.Environment.GetEnvironmentVariable("HOME")}/.microsoft/usersecrets/enterprise-certificate/secrets.json";
@@ -38,7 +39,7 @@ namespace Digipost.Api.Client
             {
                 _logger.LogDebug($"Did not find file at {pathToSecrets}");
             }
-            
+
             var certificateConfig = File.ReadAllText(pathToSecrets);
             var deserializeObject = JsonConvert.DeserializeObject<Dictionary<string, string>>(certificateConfig);
 


### PR DESCRIPTION
We use Newtonsoft to read the `secrets.json` file to get secrets (sertifikat path and passord). Newtonsoft is an transitive dependency through .NETStandard 2.0 (v 10.0.1). This is vulnerable if for DoS due to improper handling of deeply nested json-files. This should not usually be a problem since users of this client library them selves craft the json file that is read. Anyway, we do the mitigation recommended by by setting the MaxDepth to 128. This is quite deep, and should not be an issue for anyone.
ref.: https://github.com/advisories/GHSA-5crp-9r3c-p9vr