### PR TITLE
Fix bug where SenderId is not set in XML

### DIFF
--- a/Digipost.Api.Client.Send.Tests/SendDataTransferObjectConverterTests.cs
+++ b/Digipost.Api.Client.Send.Tests/SendDataTransferObjectConverterTests.cs
@@ -221,6 +221,7 @@ namespace Digipost.Api.Client.Send.Tests
                     new V8.Message()
                     {
                         Sender_Id = sender.Id,
+                        Sender_IdSpecified = true,
                         Recipient = new Message_Recipient()
                         {
                             Name_And_Address = new Name_And_Address()
@@ -291,6 +292,7 @@ namespace Digipost.Api.Client.Send.Tests
                     new V8.Message()
                     {
                         Sender_Id = sender.Id,
+                        Sender_IdSpecified = true,
                         Recipient = new V8.Message_Recipient()
                         {
                             Name_And_Address = new V8.Name_And_Address()

--- a/Digipost.Api.Client.Send/SendDataTransferObjectConverter.cs
+++ b/Digipost.Api.Client.Send/SendDataTransferObjectConverter.cs
@@ -17,6 +17,7 @@ namespace Digipost.Api.Client.Send
             var messageDto = new V8.Message
             {
                 Sender_Id = message.Sender.Id,
+                Sender_IdSpecified = true,
                 Primary_Document = primaryDocumentDataTransferObject,
                 Message_Id = message.Id,
                 Recipient = DataTransferObjectConverter.ToDataTransferObject(message.DigipostRecipient)

--- a/Digipost.Api.Client.Tests/DomainUtility.cs
+++ b/Digipost.Api.Client.Tests/DomainUtility.cs
@@ -67,6 +67,7 @@ namespace Digipost.Api.Client.Tests
             var message = new Message()
             {
                 Sender_Id = long.Parse("1010"),
+                Sender_IdSpecified = true,
                 Message_Id = "ThatMessageId",
                 Primary_Document = new V8.Document()
                 {


### PR DESCRIPTION
A while back we had to change the code generation rig. While doing that an boolan telling the xml mapping code to serialize SenderId was not set. The consequence is that SenderId is not added to the xml leaving the broker as the sender in the sent messager.