### PR TITLE
Can send direct to print

### DIFF
--- a/Digipost.Api.Client.Archive/ArchiveApi.cs
+++ b/Digipost.Api.Client.Archive/ArchiveApi.cs
@@ -129,7 +129,7 @@ namespace Digipost.Api.Client.Archive
 
         public async Task<Archive> ArchiveDocumentsAsync(Archive archiveWithDocuments)
         {
-            _logger.LogDebug($"Outgoing archive '{archiveWithDocuments.ArchiveDocuments.Count}' documents to archive: {archiveWithDocuments.Name ?? "default"}");
+            _logger.LogDebug("Outgoing archive '{count}' documents to archive: {name}", archiveWithDocuments.ArchiveDocuments.Count, archiveWithDocuments.Name ?? "default");
 
             var archiveUri = _root.GetArchiveDocumentsUri();
 
@@ -143,7 +143,7 @@ namespace Digipost.Api.Client.Archive
 
             var result = ArchiveDataTransferObjectConverter.FromDataTransferObject(await task.ConfigureAwait(false));
 
-            _logger.LogDebug($"Response received for archiving to '{archiveWithDocuments.Name ?? "default"}'");
+            _logger.LogDebug("Response received for archiving to '{name}'", archiveWithDocuments.Name ?? "default");
 
             return result;
         }

--- a/Digipost.Api.Client.Common.Tests/DataTransferObjectConverterTests.cs
+++ b/Digipost.Api.Client.Common.Tests/DataTransferObjectConverterTests.cs
@@ -36,7 +36,7 @@ namespace Digipost.Api.Client.Common.Tests
                     Addressline1 = source.AddressLine1,
                     Addressline2 = source.AddressLine2,
                     Addressline3 = source.AddressLine3,
-                    Addressline4 = source.Addressline4
+                    Addressline4 = source.AddressLine4
                 };
 
                 //Act
@@ -541,7 +541,7 @@ namespace Digipost.Api.Client.Common.Tests
                         Addressline1 = source.Address.AddressLine1,
                         Addressline2 = source.Address.AddressLine2,
                         Addressline3 = source.Address.AddressLine3,
-                        Addressline4 = ((ForeignAddress) source.Address).Addressline4
+                        Addressline4 = ((ForeignAddress) source.Address).AddressLine4
                     }
                 };
 
@@ -604,7 +604,7 @@ namespace Digipost.Api.Client.Common.Tests
                         Addressline1 = source.Address.AddressLine1,
                         Addressline2 = source.Address.AddressLine2,
                         Addressline3 = source.Address.AddressLine3,
-                        Addressline4 = ((ForeignAddress) source.Address).Addressline4
+                        Addressline4 = ((ForeignAddress) source.Address).AddressLine4
                     }
                 };
 

--- a/Digipost.Api.Client.Common.Tests/Print/ForeignAddressTests.cs
+++ b/Digipost.Api.Client.Common.Tests/Print/ForeignAddressTests.cs
@@ -28,7 +28,7 @@ namespace Digipost.Api.Client.Common.Tests.Print
                 Assert.Equal("Adresselinje1", foreignAddress.AddressLine1);
                 Assert.Equal("Adresselinje2", foreignAddress.AddressLine2);
                 Assert.Equal("Adresselinje3", foreignAddress.AddressLine3);
-                Assert.Equal("Adresselinje4", foreignAddress.Addressline4);
+                Assert.Equal("Adresselinje4", foreignAddress.AddressLine4);
             }
         }
     }

--- a/Digipost.Api.Client.Common/DataTransferObjectConverter.cs
+++ b/Digipost.Api.Client.Common/DataTransferObjectConverter.cs
@@ -279,7 +279,7 @@ namespace Digipost.Api.Client.Common
                 Addressline1 = foreignAddress.AddressLine1,
                 Addressline2 = foreignAddress.AddressLine2,
                 Addressline3 = foreignAddress.AddressLine3,
-                Addressline4 = foreignAddress.Addressline4,
+                Addressline4 = foreignAddress.AddressLine4,
             };
 
             if (foreignAddress.CountryIdentifier == CountryIdentifier.Country)

--- a/Digipost.Api.Client.Common/Print/ForeignAddress.cs
+++ b/Digipost.Api.Client.Common/Print/ForeignAddress.cs
@@ -12,20 +12,25 @@ namespace Digipost.Api.Client.Common.Print
         /// <param name="addressLine1">First address line.</param>
         /// <param name="addressLine2">Second address line.</param>
         /// <param name="addressLine3">Third address line.</param>
-        /// <param name="addressline4">Fourth address line.</param>
+        /// <param name="addressLine4">Fourth address line.</param>
         public ForeignAddress(CountryIdentifier countryIdentifier, string countryIdentifierValue,
-            string addressLine1, string addressLine2 = null, string addressLine3 = null, string addressline4 = null)
+            string addressLine1, string addressLine2 = null, string addressLine3 = null, string addressLine4 = null)
             : base(addressLine1, addressLine2, addressLine3)
         {
-            Addressline4 = addressline4;
+            AddressLine4 = addressLine4;
             CountryIdentifier = countryIdentifier;
             CountryIdentifierValue = countryIdentifierValue;
         }
 
-        public string Addressline4 { get; set; }
+        public string AddressLine4 { get; set; }
 
         public string CountryIdentifierValue { get; set; }
 
         public CountryIdentifier CountryIdentifier { get; set; }
+
+        public override string ToString()
+        {
+            return $"Country: {CountryIdentifier.Country}, AddressLine1: {AddressLine1}, AddressLine2: {AddressLine2}, AddressLine3: {AddressLine3}, AddressLine4: {AddressLine4}";
+        }
     }
 }

--- a/Digipost.Api.Client.Common/Print/IForeignAddress.cs
+++ b/Digipost.Api.Client.Common/Print/IForeignAddress.cs
@@ -4,7 +4,7 @@ namespace Digipost.Api.Client.Common.Print
 {
     public interface IForeignAddress : IAddress
     {
-        string Addressline4 { get; set; }
+        string AddressLine4 { get; set; }
 
         /// <summary>
         ///     The value of the contryIdentifier.

--- a/Digipost.Api.Client.Common/Print/NorwegianAddress.cs
+++ b/Digipost.Api.Client.Common/Print/NorwegianAddress.cs
@@ -21,5 +21,10 @@
         public string PostalCode { get; set; }
 
         public string City { get; set; }
+
+        public override string ToString()
+        {
+            return $"City: {City}, PostalCode: {PostalCode}, AddressLine1: {AddressLine1}, AddressLine2: {AddressLine2}, AddressLine3: {AddressLine3}";
+        }
     }
 }

--- a/Digipost.Api.Client.Common/Print/PrintDetails.cs
+++ b/Digipost.Api.Client.Common/Print/PrintDetails.cs
@@ -19,7 +19,12 @@ namespace Digipost.Api.Client.Common.Print
         public PrintColors PrintColors { get; set; }
 
         public NondeliverableHandling NondeliverableHandling { get; set; }
-        
+
         public IPrintInstructions PrintInstructions { get; set; }
+
+        public override string ToString()
+        {
+            return PrintRecipient.ToString();
+        }
     }
 }

--- a/Digipost.Api.Client.Common/Print/PrintRecipient.cs
+++ b/Digipost.Api.Client.Common/Print/PrintRecipient.cs
@@ -6,5 +6,10 @@
             : base(name, address)
         {
         }
+
+        public override string ToString()
+        {
+            return $"FullName: {Name}, Address: {Address}";
+        }
     }
 }

--- a/Digipost.Api.Client.Docs/SendExamples.cs
+++ b/Digipost.Api.Client.Docs/SendExamples.cs
@@ -131,6 +131,25 @@ namespace Digipost.Api.Client.Docs
             var result = client.SendMessage(messageWithFallbackToPrint);
         }
 
+        public void SendLetterWithDirectToPrint()
+        {
+            var printDetails =
+                new PrintDetails(
+                    printRecipient: new PrintRecipient(
+                        "Ola Nordmann",
+                        new NorwegianAddress("0460", "Oslo", "Prinsensveien 123")),
+                    printReturnRecipient: new PrintReturnRecipient(
+                        "Kari Nordmann",
+                        new NorwegianAddress("0400", "Oslo", "Akers Àle 2"))
+                );
+
+            var primaryDocument = new Document(subject: "document subject", fileType: "pdf", path: @"c:\...\document.pdf");
+
+            var messageToPrint = new PrintMessage(sender, printDetails, primaryDocument);
+
+            var result = client.SendMessage(messageToPrint);
+        }
+
         public void SendLetterWithPrintIfUnread()
         {
             var recipient = new RecipientByNameAndAddress(

--- a/Digipost.Api.Client.Send/Message.cs
+++ b/Digipost.Api.Client.Send/Message.cs
@@ -33,7 +33,7 @@ namespace Digipost.Api.Client.Send
         public IDigipostRecipient DigipostRecipient { get; set; }
 
         public IPrintDetails PrintDetails { get; set; }
-        
+
         public IPrintIfUnread PrintIfUnread { get; set; }
 
         public bool PrintIfUnreadAfterSpecified => PrintIfUnread != null;
@@ -47,5 +47,10 @@ namespace Digipost.Api.Client.Send
         public IDocument PrimaryDocument { get; set; }
 
         public List<IDocument> Attachments { get; set; }
+
+        public override string ToString()
+        {
+            return DigipostRecipient.ToString();
+        }
     }
 }

--- a/Digipost.Api.Client.Send/PrintMessage.cs
+++ b/Digipost.Api.Client.Send/PrintMessage.cs
@@ -10,5 +10,10 @@ namespace Digipost.Api.Client.Send
         {
             PrintDetails = printDetails;
         }
+
+        public override string ToString()
+        {
+            return PrintDetails.ToString();
+        }
     }
 }

--- a/Digipost.Api.Client.Send/PrintMessage.cs
+++ b/Digipost.Api.Client.Send/PrintMessage.cs
@@ -1,0 +1,14 @@
+using Digipost.Api.Client.Common;
+using Digipost.Api.Client.Common.Print;
+
+namespace Digipost.Api.Client.Send
+{
+    public class PrintMessage : Message
+    {
+        public PrintMessage(Sender sender, IPrintDetails printDetails, IDocument primaryDocument)
+            : base(sender, null, primaryDocument)
+        {
+            PrintDetails = printDetails;
+        }
+    }
+}

--- a/Digipost.Api.Client.Send/SendDataTransferObjectConverter.cs
+++ b/Digipost.Api.Client.Send/SendDataTransferObjectConverter.cs
@@ -19,12 +19,21 @@ namespace Digipost.Api.Client.Send
                 Sender_Id = message.Sender.Id,
                 Sender_IdSpecified = true,
                 Primary_Document = primaryDocumentDataTransferObject,
-                Message_Id = message.Id,
-                Recipient = DataTransferObjectConverter.ToDataTransferObject(message.DigipostRecipient)
+                Message_Id = message.Id
             };
 
-            messageDto.Recipient.Print_Details = DataTransferObjectConverter.ToDataTransferObject(message.PrintDetails);
-
+            if (message is PrintMessage)
+            {
+                messageDto.Recipient = new Message_Recipient()
+                {
+                    Print_Details = DataTransferObjectConverter.ToDataTransferObject(message.PrintDetails)
+                };
+            }
+            else
+            {
+                messageDto.Recipient = DataTransferObjectConverter.ToDataTransferObject(message.DigipostRecipient);
+                messageDto.Recipient.Print_Details = DataTransferObjectConverter.ToDataTransferObject(message.PrintDetails);
+            }
 
             foreach (var document in message.Attachments.Select(ToDataTransferObject))
             {

--- a/Digipost.Api.Client.Tests/Smoke/ClientSmokeTestHelper.cs
+++ b/Digipost.Api.Client.Tests/Smoke/ClientSmokeTestHelper.cs
@@ -6,6 +6,7 @@ using Digipost.Api.Client.Common;
 using Digipost.Api.Client.Common.Entrypoint;
 using Digipost.Api.Client.Common.Enums;
 using Digipost.Api.Client.Common.Identify;
+using Digipost.Api.Client.Common.Print;
 using Digipost.Api.Client.Common.Recipient;
 using Digipost.Api.Client.Common.Relations;
 using Digipost.Api.Client.Common.Search;
@@ -39,6 +40,9 @@ namespace Digipost.Api.Client.Tests.Smoke
 
         //Gradually built state, search
         private ISearchDetailsResult _searchResult;
+
+        //Gradually built state, printMessage
+        private IPrintDetails _printDetails;
 
         public ClientSmokeTestHelper(TestSender testSender, bool withoutDataTypesProject = false)
         {
@@ -108,6 +112,19 @@ namespace Digipost.Api.Client.Tests.Smoke
             return this;
         }
 
+        public ClientSmokeTestHelper SendPrintMessage()
+        {
+            Assert_state(_printDetails);
+
+            _messageDeliveryResult = _digipostClient.SendMessage(
+                new PrintMessage(new Sender(_testSender.Id), _printDetails, _primary)
+                {
+                    Attachments = _attachments
+                });
+
+            return this;
+        }
+
         public void Expect_message_to_have_status(MessageStatus messageStatus)
         {
             Assert_state(_messageDeliveryResult);
@@ -150,6 +167,19 @@ namespace Digipost.Api.Client.Tests.Smoke
         {
             _searchResult = _digipostClient.Search("Børre");
 
+            return this;
+        }
+
+        public ClientSmokeTestHelper ToPrintDirectly()
+        {
+            _printDetails = new PrintDetails(
+                printRecipient: new PrintRecipient(
+                    "Ola Nordmann",
+                    new NorwegianAddress("0460", "Oslo", "Prinsensveien 123")),
+                printReturnRecipient: new PrintReturnRecipient(
+                    "Kari Nordmann",
+                    new NorwegianAddress("0400", "Oslo", "Akers Àle 2"))
+            );
             return this;
         }
 

--- a/Digipost.Api.Client.Tests/Smoke/ClientSmokeTests.cs
+++ b/Digipost.Api.Client.Tests/Smoke/ClientSmokeTests.cs
@@ -48,6 +48,16 @@ namespace Digipost.Api.Client.Tests.Smoke
         }
 
         [Fact(Skip = "SmokeTest")]
+        public void Can_send_direct_to_print()
+        {
+            _client
+                .Create_message_with_primary_document()
+                .ToPrintDirectly()
+                .SendPrintMessage()
+                .Expect_message_to_have_status(MessageStatus.DeliveredToPrint);
+        }
+
+        [Fact(Skip = "SmokeTest")]
         public void Can_send_document_with_raw_datatype_to_digipost_user()
         {
             const string raw = "<?xml version=\"1.0\" encoding=\"utf-8\"?><externalLink xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://api.digipost.no/schema/datatypes\"><url>https://www.test.no</url><description>This was raw string</description></externalLink>";

--- a/Digipost.Api.Client/Api/SendMessage.cs
+++ b/Digipost.Api.Client/Api/SendMessage.cs
@@ -39,7 +39,7 @@ namespace Digipost.Api.Client.Api
 
         public async Task<IMessageDeliveryResult> SendMessageAsync(IMessage message, bool skipMetaDataValidation = false)
         {
-            _logger.LogDebug($"Outgoing Digipost message to Recipient: {message.DigipostRecipient}");
+            _logger.LogDebug($"Outgoing Digipost message to Recipient: {message}");
 
             var messageDeliveryResultTask = RequestHelper.PostMessage<V8.Message_Delivery>(message, _root.GetSendMessageUri(), skipMetaDataValidation);
 

--- a/Digipost.Api.Client/Api/SendMessage.cs
+++ b/Digipost.Api.Client/Api/SendMessage.cs
@@ -1,14 +1,13 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Digipost.Api.Client.Common;
 using Digipost.Api.Client.Common.Entrypoint;
 using Digipost.Api.Client.Common.Identify;
-using Digipost.Api.Client.Common.Relations;
 using Digipost.Api.Client.Common.Search;
 using Digipost.Api.Client.Extensions;
 using Digipost.Api.Client.Send;
 using Microsoft.Extensions.Logging;
+using V8;
 
 namespace Digipost.Api.Client.Api
 {
@@ -39,16 +38,16 @@ namespace Digipost.Api.Client.Api
 
         public async Task<IMessageDeliveryResult> SendMessageAsync(IMessage message, bool skipMetaDataValidation = false)
         {
-            _logger.LogDebug($"Outgoing Digipost message to Recipient: {message}");
+            _logger.LogDebug("Outgoing Digipost message to Recipient: {message}", message);
 
-            var messageDeliveryResultTask = RequestHelper.PostMessage<V8.Message_Delivery>(message, _root.GetSendMessageUri(), skipMetaDataValidation);
+            var messageDeliveryResultTask = RequestHelper.PostMessage<Message_Delivery>(message, _root.GetSendMessageUri(), skipMetaDataValidation);
 
             if (messageDeliveryResultTask.IsFaulted && messageDeliveryResultTask.Exception != null)
                 throw messageDeliveryResultTask.Exception?.InnerException;
 
             var messageDeliveryResult = SendDataTransferObjectConverter.FromDataTransferObject(await messageDeliveryResultTask.ConfigureAwait(false));
 
-            _logger.LogDebug($"Response received for message to recipient, {message.DigipostRecipient}: '{messageDeliveryResult.Status}'. Will be available to Recipient at {messageDeliveryResult.DeliveryTime}.");
+            _logger.LogDebug("Response received for message to recipient, {message}: '{status}'. Will be available to Recipient at {deliverytime}.", message, messageDeliveryResult.Status, messageDeliveryResult.DeliveryTime);
 
             return messageDeliveryResult;
         }
@@ -60,15 +59,15 @@ namespace Digipost.Api.Client.Api
 
         public async Task<IIdentificationResult> IdentifyAsync(IIdentification identification)
         {
-            _logger.LogDebug($"Outgoing identification request: {identification}");
+            _logger.LogDebug("Outgoing identification request: {identification}", identification);
 
-            var identifyResponse = RequestHelper.PostIdentification<V8.Identification_Result>(identification, _root.GetIdentifyRecipientUri());
+            var identifyResponse = RequestHelper.PostIdentification<Identification_Result>(identification, _root.GetIdentifyRecipientUri());
 
             if (identifyResponse.IsFaulted)
             {
                 var exception = identifyResponse.Exception?.InnerException;
 
-                _logger.LogWarning($"Identification failed, {exception}");
+                _logger.LogWarning("Identification failed, {exception}", exception);
 
                 if (identifyResponse.Exception != null)
                     throw identifyResponse.Exception.InnerException;
@@ -77,7 +76,7 @@ namespace Digipost.Api.Client.Api
             var identificationResultDataTransferObject = await identifyResponse.ConfigureAwait(false);
             var identificationResult = DataTransferObjectConverter.FromDataTransferObject(identificationResultDataTransferObject);
 
-            _logger.LogDebug($"Response received for identification to recipient, ResultType '{identificationResult.ResultType}', Data '{identificationResult.Data}'.");
+            _logger.LogDebug("Response received for identification to recipient, ResultType '{resultType}', Data '{data}'.", identificationResult.ResultType, identificationResult.Data);
 
             return identificationResult;
         }
@@ -89,7 +88,7 @@ namespace Digipost.Api.Client.Api
 
         public async Task<ISearchDetailsResult> SearchAsync(string search)
         {
-            _logger.LogDebug($"Outgoing search request, term: '{search}'.");
+            _logger.LogDebug("Outgoing search request, term: '{search}'.", search);
 
             search = search.RemoveReservedUriCharacters();
             var uri = _root.GetRecipientSearchUri(search);
@@ -103,11 +102,11 @@ namespace Digipost.Api.Client.Api
                 return await taskSource.Task.ConfigureAwait(false);
             }
 
-            var searchDetailsResultDataTransferObject = await RequestHelper.Get<V8.Recipients>(uri).ConfigureAwait(false);
+            var searchDetailsResultDataTransferObject = await RequestHelper.Get<Recipients>(uri).ConfigureAwait(false);
 
             var searchDetailsResult = DataTransferObjectConverter.FromDataTransferObject(searchDetailsResultDataTransferObject);
 
-            _logger.LogDebug($"Response received for search with term '{search}' retrieved.");
+            _logger.LogDebug("Response received for search with term '{search}' retrieved.", search);
 
             return searchDetailsResult;
         }

--- a/Digipost.Api.Client/CertificateReader.cs
+++ b/Digipost.Api.Client/CertificateReader.cs
@@ -32,12 +32,12 @@ namespace Digipost.Api.Client
         X509Certificate2 ReadCertificatePrivate()
         {
             var pathToSecrets = $"{System.Environment.GetEnvironmentVariable("HOME")}/.microsoft/usersecrets/enterprise-certificate/secrets.json";
-            _logger.LogDebug($"Reading certificate details from secrets file: {pathToSecrets}");
+            _logger.LogDebug("Reading certificate details from secrets file: {pathToSecrets}", pathToSecrets);
             var fileExists = File.Exists(pathToSecrets);
 
             if (!fileExists)
             {
-                _logger.LogDebug($"Did not find file at {pathToSecrets}");
+                _logger.LogDebug("Did not find file at {pathToSecrets}", pathToSecrets);
             }
 
             var certificateConfig = File.ReadAllText(pathToSecrets);
@@ -46,7 +46,7 @@ namespace Digipost.Api.Client
             deserializeObject.TryGetValue("Certificate:Path:Absolute", out var certificatePath);
             deserializeObject.TryGetValue("Certificate:Password", out var certificatePassword);
 
-            _logger.LogDebug("Reading certificate from path found in secrets file: " + certificatePath);
+            _logger.LogDebug("Reading certificate from path found in secrets file: {certificatePath}",certificatePath);
 
             return new X509Certificate2(certificatePath, certificatePassword, X509KeyStorageFlags.Exportable);
         }

--- a/docs/_v14_0/2_send_messages.md
+++ b/docs/_v14_0/2_send_messages.md
@@ -149,6 +149,28 @@ var messageWithPrintIfUnread = new Message(sender, recipient, primaryDocument)
 var result = client.SendMessage(messageWithPrintIfUnread);
 ```
 
+### Send letter to print without any Digipost addressing information (directly to print)
+
+```csharp
+
+var printDetails =
+    new PrintDetails(
+        printRecipient: new PrintRecipient(
+            "Ola Nordmann",
+            new NorwegianAddress("0460", "Oslo", "Prinsensveien 123")),
+        printReturnRecipient: new PrintReturnRecipient(
+            "Kari Nordmann",
+            new NorwegianAddress("0400", "Oslo", "Akers Àle 2"))
+    );
+
+var primaryDocument = new Document(subject: "document subject", fileType: "pdf", path: @"c:\...\document.pdf");
+
+var messageToPrint = new PrintMessage(sender, printDetails, primaryDocument)
+
+var result = client.SendMessage(messageToPrint);
+// MessageStatus.DeliveredToPrint
+```
+
 ### Send letter with higher security level
 
 ```csharp


### PR DESCRIPTION
The direct to print feature is a very specific case where we want the message only to go to print without checking if a recipient has a Digipost account or not.

To keep the api simple I created a new type PrintMessage that excludes Digipost recipient addressing all together so that the api should be easy to use.

I also improved the debug logging. Most notably the use of static strings so that we dont concatenate strings unnecessary.