### PR TITLE
Add support to fetch SenderInformation

### DIFF
--- a/Digipost.Api.Client.Common/DataTransferObjectConverter.cs
+++ b/Digipost.Api.Client.Common/DataTransferObjectConverter.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Digipost.Api.Client.Common.Entrypoint;
 using Digipost.Api.Client.Common.Enums;
 using Digipost.Api.Client.Common.Extensions;
 using Digipost.Api.Client.Common.Identify;
 using Digipost.Api.Client.Common.Print;
 using Digipost.Api.Client.Common.Recipient;
 using Digipost.Api.Client.Common.Search;
+using Digipost.Api.Client.Common.SenderInfo;
 using Digipost.Api.Client.Send;
 using V8;
 using Identification = V8.Identification;
@@ -291,6 +293,39 @@ namespace Digipost.Api.Client.Common
             {
                 Links = entrypoint.Link.FromDataTransferObject()
             };
+        }
+
+        internal static SenderInformation FromDataTransferObject(this Sender_Information dto)
+        {
+            var notValidSender = dto.Status == Sender_Status.NO_INFO_AVAILABLE;
+            if (notValidSender)
+            {
+                return new SenderInformation(dto.Status.ToSenderStatus());
+            }
+
+            return new SenderInformation(
+                new Sender(dto.Sender_Id),
+                dto.Status.ToSenderStatus(),
+                dto.Supported_Features.FromDataTransferObject()
+            );
+        }
+
+        internal static SenderStatus ToSenderStatus(this Sender_Status dto)
+        {
+            switch (dto)
+            {
+                case Sender_Status.VALID_SENDER:
+                    return SenderStatus.ValidSender;
+                case Sender_Status.NO_INFO_AVAILABLE:
+                    return SenderStatus.NoInfoAvailable;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        internal static IEnumerable<SenderFeature> FromDataTransferObject(this Collection<Feature> dto)
+        {
+            return dto.Select(d => new SenderFeature(d.Value, d.Param));
         }
 
         internal static IIdentificationResult FromDataTransferObject(this Identification_Result identificationResultDto)

--- a/Digipost.Api.Client.Common/Entrypoint/Entrypoint.cs
+++ b/Digipost.Api.Client.Common/Entrypoint/Entrypoint.cs
@@ -25,6 +25,15 @@ namespace Digipost.Api.Client.Common.Entrypoint
             return new ApiRootUri(sender);
         }
 
+        public SenderInformationUri GetSenderInformationUri(Sender sender)
+        {
+            return new SenderInformationUri(Links["GET_SENDER_INFORMATION"], sender);
+        }
+        public SenderInformationUri GetSenderInformationUri(string organisationNumber, string partId)
+        {
+            return new SenderInformationUri(Links["GET_SENDER_INFORMATION"], organisationNumber, partId);
+        }
+
         public GetInboxUri GetGetInboxUri(int offset = 0, int limit = 100)
         {
             return new GetInboxUri(Links["GET_INBOX"], offset, limit);

--- a/Digipost.Api.Client.Common/Relations/ApiRelations.cs
+++ b/Digipost.Api.Client.Common/Relations/ApiRelations.cs
@@ -16,6 +16,20 @@ namespace Digipost.Api.Client.Common.Relations
         }
     }
 
+    public class SenderInformationUri : Uri
+    {
+        public SenderInformationUri(Link link, Sender sender)
+            : base($"{link.Uri}/{sender.Id}", UriKind.Absolute)
+        {
+
+        }
+        public SenderInformationUri(Link link, string organisationNumber, string partId)
+            : base($"{link.Uri}?org_id={organisationNumber}&part_id={partId}", UriKind.Absolute)
+        {
+
+        }
+    }
+
     public class SendMessageUri : Uri
     {
         public SendMessageUri(Link link)

--- a/Digipost.Api.Client.Common/SenderInfo/SenderInformation.cs
+++ b/Digipost.Api.Client.Common/SenderInfo/SenderInformation.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace Digipost.Api.Client.Common.SenderInfo
+{
+    public class SenderInformation
+    {
+        public Sender Sender { get; }
+
+        public SenderStatus SenderStatus { get; }
+
+        public IEnumerable<SenderFeature> SenderFeatures { get; }
+
+        public bool IsValidSender => SenderStatus == SenderStatus.ValidSender && Sender.Id > 0;
+
+        public SenderInformation(SenderStatus senderStatus)
+        {
+            SenderStatus = senderStatus;
+        }
+
+        public SenderInformation(Sender sender, SenderStatus senderStatus, IEnumerable<SenderFeature> senderFeatures)
+        {
+            Sender = sender;
+            SenderStatus = senderStatus;
+            SenderFeatures = senderFeatures;
+        }
+    }
+
+    public class SenderFeature
+    {
+        public string Identificator { get; }
+
+        public string Param { get; }
+
+        public SenderFeature(string identificator, string param)
+        {
+            Identificator = identificator;
+            Param = param;
+        }
+    }
+
+}

--- a/Digipost.Api.Client.Common/SenderInfo/SenderStatus.cs
+++ b/Digipost.Api.Client.Common/SenderInfo/SenderStatus.cs
@@ -1,0 +1,17 @@
+namespace Digipost.Api.Client.Common.SenderInfo
+{
+    public enum SenderStatus
+    {
+        /// <summary>
+        /// No information about the requested sender could be retrieved. This may either be because the
+        /// sender does not exist, or the broker is not authorized to send on behalf of the sender.
+        /// </summary>
+        NoInfoAvailable,
+
+        /// <summary>
+        /// The sender exists in Digipost, and the broker is authorized to act on behalf of
+        /// the sender (typically send messages).
+        /// </summary>
+        ValidSender
+    }
+}

--- a/Digipost.Api.Client.Common/SenderOrganisation.cs
+++ b/Digipost.Api.Client.Common/SenderOrganisation.cs
@@ -1,0 +1,20 @@
+namespace Digipost.Api.Client.Common
+{
+    /// <summary>
+    ///     A SenderOrganisation is the same as a @See Sender. But the identification
+    ///     is by OrganisationNumber instead of the id in Digipost.
+    ///     A organisation can have several accounts and to separate different accounts
+    ///     a PartId can be given the account in Digipost.
+    /// </summary>
+    public class SenderOrganisation
+    {
+        public string OrganisationNumber { get; }
+        public string PartId { get; }
+
+        public SenderOrganisation(string organisationNumber, string partId)
+        {
+            OrganisationNumber = organisationNumber;
+            PartId = partId;
+        }
+    }
+}

--- a/Digipost.Api.Client.Docs/SendExamples.cs
+++ b/Digipost.Api.Client.Docs/SendExamples.cs
@@ -4,6 +4,7 @@ using Digipost.Api.Client.Common.Enums;
 using Digipost.Api.Client.Common.Identify;
 using Digipost.Api.Client.Common.Print;
 using Digipost.Api.Client.Common.Recipient;
+using Digipost.Api.Client.Common.Relations;
 using Digipost.Api.Client.Common.Utilities;
 using Digipost.Api.Client.DataTypes.Core;
 using Digipost.Api.Client.Send;
@@ -423,6 +424,19 @@ namespace Digipost.Api.Client.Docs
             );
 
             // Create Message and send using the client as specified in other examples.
+        }
+
+        public void SendMessageWithSenderInformation()
+        {
+            var senderInformation = client.GetSenderInformation(sender, new SenderOrganisation("9876543210", "thePartId"));
+
+            var message = new Message(
+                senderInformation.Sender,
+                new RecipientById(IdentificationType.PersonalIdentificationNumber, "311084xxxx"),
+                new Document(subject: "Attachment", fileType: "txt", path: @"c:\...\document.txt")
+            );
+
+            var result = client.SendMessage(message);
         }
     }
 }

--- a/Digipost.Api.Client.Tests/Smoke/ClientSmokeTestHelper.cs
+++ b/Digipost.Api.Client.Tests/Smoke/ClientSmokeTestHelper.cs
@@ -9,6 +9,7 @@ using Digipost.Api.Client.Common.Print;
 using Digipost.Api.Client.Common.Recipient;
 using Digipost.Api.Client.Common.Relations;
 using Digipost.Api.Client.Common.Search;
+using Digipost.Api.Client.Common.SenderInfo;
 using Digipost.Api.Client.Common.Utilities;
 using Digipost.Api.Client.Send;
 using Digipost.Api.Client.Tests.Utilities;
@@ -47,6 +48,7 @@ namespace Digipost.Api.Client.Tests.Smoke
         private RequestForRegistration _requestForRegistration;
 
         private DocumentStatus _documentStatus;
+        private SenderInformation _senderInformation;
 
         public ClientSmokeTestHelper(TestSender testSender, bool withoutDataTypesProject = false)
         {
@@ -243,6 +245,19 @@ namespace Digipost.Api.Client.Tests.Smoke
             Assert_state(_documentStatus);
             Assert.Equal(_documentStatus.DeliveryMethod, deliveryMethod);
             Assert.Equal(_documentStatus.DeliveryStatus, deliveryStatus);
+        }
+
+        public ClientSmokeTestHelper GetSenderInformation()
+        {
+            //_senderInformation = _digipostClient.GetSenderInformation(_root.GetSenderInformationUri(new Sender(_testSender.Id)));
+            _senderInformation = _digipostClient.GetSenderInformation(new Sender(_testSender.Id), new SenderOrganisation("984661185", "signering"));
+            return this;
+        }
+
+        public void Expect_valid_sender_information()
+        {
+            Assert_state(_senderInformation);
+            Assert.True(_senderInformation.IsValidSender);
         }
     }
 }

--- a/Digipost.Api.Client.Tests/Smoke/ClientSmokeTests.cs
+++ b/Digipost.Api.Client.Tests/Smoke/ClientSmokeTests.cs
@@ -39,6 +39,14 @@ namespace Digipost.Api.Client.Tests.Smoke
         }
 
         [Fact(Skip = "SmokeTest")]
+        public void Get_sender_information()
+        {
+            _client
+                .GetSenderInformation()
+                .Expect_valid_sender_information();
+        }
+
+        [Fact(Skip = "SmokeTest")]
         public void Can_send_document_digipost_user()
         {
             _client

--- a/docs/_v14_0/2_send_messages.md
+++ b/docs/_v14_0/2_send_messages.md
@@ -578,3 +578,22 @@ var documentStatus = _digipostClient.GetDocumentStatus(sender).GetDocumentStatus
 ```
 
 This can be useful if you use fallback to print, print-if-unread, request for registration etc. 
+
+### Get Sender by organisation number and a part id and send a message
+
+In very specific usecases where a broker organisation has multiple sub-organisations in Digipost
+it is possible to send with organisation number and a partid. The partid can be used to distinguish 
+between different divisions or however the organisation sees fit. This makes it possible 
+to not have to store the Digipost account id, but in stead fetch this information from the api.
+
+```csharp
+var senderInformation = client.GetSenderInformation(sender, new SenderOrganisation("9876543210", "thePartId"));
+
+var message = new Message(
+    senderInformation.Sender,
+    new RecipientById(IdentificationType.PersonalIdentificationNumber, "311084xxxx"),
+    new Document(subject: "Attachment", fileType: "txt", path: @"c:\...\document.txt")
+);
+
+var result = client.SendMessage(message);
+```


### PR DESCRIPTION
SenderInformation can provide a Sender (id) by means of organisation number and partid if the organisation is set up with this information and you as a broker is authorised to broker for the given account.