### PR TITLE
Document events

### DIFF
--- a/Digipost.Api.Client.Common.Tests/Extensions/EnumExtensionsTests.cs
+++ b/Digipost.Api.Client.Common.Tests/Extensions/EnumExtensionsTests.cs
@@ -28,6 +28,24 @@ namespace Digipost.Api.Client.Common.Tests.Extensions
             }
         }
 
+        public class ToEventType
+        {
+            [Fact]
+            public void Convert_All_Enum_Values()
+            {
+                var enumValues = Enum.GetValues(typeof(DocumentEventType));
+                var enumValuesDto = Enum.GetValues(typeof(V8.Event_Type));
+
+                Assert.Equal(enumValues.Length, enumValuesDto.Length);
+
+                foreach (var enumValue in enumValuesDto)
+                {
+                    var currentEnum = (V8.Event_Type) enumValue;
+                    currentEnum.ToEventType();
+                }
+            }
+        }
+
         public class ToSensitivityLevel
         {
             [Fact]

--- a/Digipost.Api.Client.Common/DocumentEvent.cs
+++ b/Digipost.Api.Client.Common/DocumentEvent.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Digipost.Api.Client.Common.Enums;
+
+namespace Digipost.Api.Client.Common
+{
+    public class DocumentEvents : IEnumerable<DocumentEvent>
+    {
+        private readonly IEnumerable<DocumentEvent> _events;
+
+        public DocumentEvents(IEnumerable<DocumentEvent> events)
+        {
+            _events = events;
+        }
+
+        public IEnumerator<DocumentEvent> GetEnumerator()
+        {
+            return _events.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    public class DocumentEvent
+    {
+        public Guid Guid { get; }
+
+        public DocumentEventType EventType { get; }
+
+        public DateTime Created { get; }
+
+        public DateTime DocumentCreated { get; }
+
+        public EventMetadata EventMetadata { get; set; }
+
+        public DocumentEvent(Guid guid, DocumentEventType eventType, DateTime created, DateTime documentCreated)
+        {
+            Guid = guid;
+            EventType = eventType;
+            Created = created;
+            DocumentCreated = documentCreated;
+        }
+    }
+
+    public abstract class EventMetadata
+    {
+    }
+
+    public class RequestForRegistrationExpiredMetadata : EventMetadata
+    {
+        /// <summary>
+        /// Values of FallbackChannel might be 'none' or 'print'.
+        /// </summary>
+        public string FallbackChannel { get; }
+
+        public RequestForRegistrationExpiredMetadata(string fallbackChannel)
+        {
+            FallbackChannel = fallbackChannel;
+        }
+    }
+}

--- a/Digipost.Api.Client.Common/Entrypoint/Entrypoint.cs
+++ b/Digipost.Api.Client.Common/Entrypoint/Entrypoint.cs
@@ -80,6 +80,11 @@ namespace Digipost.Api.Client.Common.Entrypoint
             return new GetArchiveDocumentByUuidUri(Links["GET_ARCHIVE_DOCUMENT_BY_UUID"], guid);
         }
 
+        public DocumentEventsUri GetDocumentEventsUri(Sender sender, DateTime from, DateTime to, int offset, int maxResults)
+        {
+            return new DocumentEventsUri(Links["DOCUMENT_EVENTS"], sender, from, to, offset, maxResults);
+        }
+
         public DocumentStatusUri GetDocumentStatusUri(Guid guid)
         {
             return new DocumentStatusUri(Links["DOCUMENT_STATUS"], guid);

--- a/Digipost.Api.Client.Common/Enums/DocumentEventType.cs
+++ b/Digipost.Api.Client.Common/Enums/DocumentEventType.cs
@@ -1,0 +1,20 @@
+namespace Digipost.Api.Client.Common.Enums
+{
+    public enum DocumentEventType
+    {
+        EmailNotificationFailed,
+        EmailMessageSent,
+        EmailMessageFailed,
+        SmsNotificationFailed,
+        Opened,
+        MoveFilesFromPublicSector,
+        Postmarked,
+        PrintFailed,
+        Shredded,
+        PeppolDelivered,
+        PeppolFailed,
+        RequestForRegistrationExpired,
+        RequestForRegistrationDeliveredDigipost,
+        RequestForRegistrationFailed,
+    }
+}

--- a/Digipost.Api.Client.Common/Extensions/EnumExtensions.cs
+++ b/Digipost.Api.Client.Common/Extensions/EnumExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Digipost.Api.Client.Common.Enums;
 using V8;
 
@@ -79,6 +81,21 @@ namespace Digipost.Api.Client.Common.Extensions
             }
         }
 
+        internal static HashAlgoritm ToHashAlgoritm(this V8.Hash_Algorithm hashAlgorithm)
+        {
+            switch (hashAlgorithm)
+            {
+                case Hash_Algorithm.NONE:
+                    return HashAlgoritm.NONE;
+                case Hash_Algorithm.MD5:
+                    return HashAlgoritm.MD5;
+                case Hash_Algorithm.SHA256:
+                    return HashAlgoritm.SHA256;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
         internal static MessageStatus ToMessageStatus(this V8.Message_Status messagestatus)
         {
             switch (messagestatus)
@@ -120,6 +137,39 @@ namespace Digipost.Api.Client.Common.Extensions
                 default:
                     throw new ArgumentOutOfRangeException(nameof(sensitivitylevel), sensitivitylevel, null);
             }
+        }
+
+        internal static DocumentEventType ToEventType(this V8.Event_Type eventType)
+        {
+            return MapEnum<DocumentEventType>(eventType);
+        }
+
+        private static TTargetEnum MapEnum<TTargetEnum>(Enum sourceEnum) where TTargetEnum : Enum
+        {
+            Type targetEnumType = typeof(TTargetEnum);
+
+            string sourceEnumName = sourceEnum.ToString();
+            string[] targetEnumNames = Enum.GetNames(targetEnumType);
+
+            string mappedValueName = targetEnumNames.FirstOrDefault(
+                targetName => string.Equals(
+                    RemoveUnderscores(targetName),
+                    RemoveUnderscores(sourceEnumName),
+                    StringComparison.OrdinalIgnoreCase
+                )
+            );
+
+            if (!string.IsNullOrEmpty(mappedValueName))
+            {
+                object mappedValue = Enum.Parse(targetEnumType, mappedValueName);
+                return (TTargetEnum)mappedValue;
+            }
+
+            throw new ArgumentException($"Enum value {sourceEnum} not found in {targetEnumType.Name} enum.");
+        }
+        private static string RemoveUnderscores(string input)
+        {
+            return Regex.Replace(input, "_", string.Empty);
         }
     }
 }

--- a/Digipost.Api.Client.Common/Relations/ApiRelations.cs
+++ b/Digipost.Api.Client.Common/Relations/ApiRelations.cs
@@ -21,12 +21,11 @@ namespace Digipost.Api.Client.Common.Relations
         public SenderInformationUri(Link link, Sender sender)
             : base($"{link.Uri}/{sender.Id}", UriKind.Absolute)
         {
-
         }
+
         public SenderInformationUri(Link link, string organisationNumber, string partId)
             : base($"{link.Uri}?org_id={organisationNumber}&part_id={partId}", UriKind.Absolute)
         {
-
         }
     }
 
@@ -171,6 +170,20 @@ namespace Digipost.Api.Client.Common.Relations
         public ArchiveDocumentDeleteUri(Link link)
             : base(link.Uri, UriKind.Absolute)
         {
+        }
+    }
+
+    public class DocumentEventsUri : Uri
+    {
+        public DocumentEventsUri(Link link, Sender sender, DateTime from, DateTime to, int offset, int maxResults)
+            : base($"{link.Uri}?sender={sender.Id}&from={DatetimeFormatter(from)}&to={DatetimeFormatter(to)}&offset={offset}&maxResults={maxResults}", UriKind.Absolute)
+        {
+
+        }
+
+        private static string DatetimeFormatter(DateTime? dt)
+        {
+            return HttpUtility.UrlEncode(dt?.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK"));
         }
     }
 

--- a/Digipost.Api.Client.Docs/DocumentsExamples.cs
+++ b/Digipost.Api.Client.Docs/DocumentsExamples.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Digipost.Api.Client.Common;
+using Digipost.Api.Client.Common.Enums;
 using Digipost.Api.Client.Send;
 
 namespace Digipost.Api.Client.Docs
@@ -11,15 +14,26 @@ namespace Digipost.Api.Client.Docs
         private static readonly Sender Sender;
 #pragma warning restore 0649
 
-        public void Hent_document_status()
+        public async void Hent_document_status()
         {
-            DocumentStatus documentStatus = Client.GetDocumentStatus(Sender)
-                .GetDocumentStatus(Guid.Parse("10ff4c99-8560-4741-83f0-1093dc4deb1c"))
-                .Result;
+            DocumentStatus documentStatus = await Client.DocumentsApi()
+                .GetDocumentStatus(Guid.Parse("10ff4c99-8560-4741-83f0-1093dc4deb1c"));
 
             // example information:
             // documentStatus.DeliveryStatus => DELIVERED
             // documentStatus.DeliveryMethod => PRINT
+        }
+
+        public async void Hent_document_events_last_5_minutes_max100()
+        {
+            // Fetch max 100 events last 5 minutes
+            // Beware that there might be more events. So you must fetch more events by adding to the offset
+            // until you get 0 or less than 100 events.
+            // Then you can start again from the previous `to` datetime as `from`
+            DocumentEvents events = await Client.DocumentsApi(Sender)
+                .GetDocumentEvents(from: DateTime.Now.Subtract(TimeSpan.FromMinutes(5)), to: DateTime.Now, offset: 0, maxResults: 100);
+
+            IEnumerable<DocumentEventType> documentEventTypes = events.Select(aEvent => aEvent.EventType);
         }
     }
 }

--- a/Digipost.Api.Client.Docs/SendExamples.cs
+++ b/Digipost.Api.Client.Docs/SendExamples.cs
@@ -4,7 +4,6 @@ using Digipost.Api.Client.Common.Enums;
 using Digipost.Api.Client.Common.Identify;
 using Digipost.Api.Client.Common.Print;
 using Digipost.Api.Client.Common.Recipient;
-using Digipost.Api.Client.Common.Relations;
 using Digipost.Api.Client.Common.Utilities;
 using Digipost.Api.Client.DataTypes.Core;
 using Digipost.Api.Client.Send;
@@ -428,7 +427,7 @@ namespace Digipost.Api.Client.Docs
 
         public void SendMessageWithSenderInformation()
         {
-            var senderInformation = client.GetSenderInformation(sender, new SenderOrganisation("9876543210", "thePartId"));
+            var senderInformation = client.GetSenderInformation(new SenderOrganisation("9876543210", "thePartId"));
 
             var message = new Message(
                 senderInformation.Sender,

--- a/Digipost.Api.Client.Tests/Smoke/ClientSmokeTestHelper.cs
+++ b/Digipost.Api.Client.Tests/Smoke/ClientSmokeTestHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Digipost.Api.Client.Common;
 using Digipost.Api.Client.Common.Entrypoint;
 using Digipost.Api.Client.Common.Enums;
@@ -49,6 +50,7 @@ namespace Digipost.Api.Client.Tests.Smoke
 
         private DocumentStatus _documentStatus;
         private SenderInformation _senderInformation;
+        private DocumentEvents _documentEvents;
 
         public ClientSmokeTestHelper(TestSender testSender, bool withoutDataTypesProject = false)
         {
@@ -215,7 +217,7 @@ namespace Digipost.Api.Client.Tests.Smoke
         public ClientSmokeTestHelper RequestForRegistration(string phonenumber)
         {
             ToPrintDirectly();
-            _requestForRegistration = new RequestForRegistration(DateTime.Now.AddDays(6), phonenumber, null, _printDetails);
+            _requestForRegistration = new RequestForRegistration(DateTime.Now.AddHours(1).AddSeconds(2), phonenumber, null, _printDetails);
             return this;
         }
 
@@ -231,12 +233,12 @@ namespace Digipost.Api.Client.Tests.Smoke
             Assert_state(_messageDeliveryResult);
             Assert_state(_primary);
 
-            _documentStatus = _digipostClient.GetDocumentStatus(new Sender(_testSender.Id)).GetDocumentStatus(Guid.Parse(_primary.Guid)).Result;
+            _documentStatus = _digipostClient.DocumentsApi(new Sender(_testSender.Id)).GetDocumentStatus(Guid.Parse(_primary.Guid)).Result;
             return this;
         }
         public ClientSmokeTestHelper FetchDocumentStatus(Guid guid)
         {
-            _documentStatus = _digipostClient.GetDocumentStatus(new Sender(_testSender.Id)).GetDocumentStatus(guid).Result;
+            _documentStatus = _digipostClient.DocumentsApi(new Sender(_testSender.Id)).GetDocumentStatus(guid).Result;
             return this;
         }
 
@@ -245,6 +247,20 @@ namespace Digipost.Api.Client.Tests.Smoke
             Assert_state(_documentStatus);
             Assert.Equal(_documentStatus.DeliveryMethod, deliveryMethod);
             Assert.Equal(_documentStatus.DeliveryStatus, deliveryStatus);
+        }
+
+        public ClientSmokeTestHelper GetDocumentEvents()
+        {
+            _documentEvents = _digipostClient.DocumentsApi(new Sender(_testSender.Id)).GetDocumentEvents(
+                DateTime.Now.Subtract(TimeSpan.FromDays(1)),
+                DateTime.Now, 0, 100
+            ).Result;
+            return this;
+        }
+
+        public void Expect_document_events()
+        {
+            Assert_state(_documentEvents);
         }
 
         public ClientSmokeTestHelper GetSenderInformation()

--- a/Digipost.Api.Client.Tests/Smoke/ClientSmokeTestHelper.cs
+++ b/Digipost.Api.Client.Tests/Smoke/ClientSmokeTestHelper.cs
@@ -265,8 +265,8 @@ namespace Digipost.Api.Client.Tests.Smoke
 
         public ClientSmokeTestHelper GetSenderInformation()
         {
-            //_senderInformation = _digipostClient.GetSenderInformation(_root.GetSenderInformationUri(new Sender(_testSender.Id)));
-            _senderInformation = _digipostClient.GetSenderInformation(new Sender(_testSender.Id), new SenderOrganisation("984661185", "signering"));
+            //_senderInformation = _digipostClient.GetSenderInformation(new Sender(_testSender.Id));
+            _senderInformation = _digipostClient.GetSenderInformation(new SenderOrganisation("984661185", "signering"));
             return this;
         }
 

--- a/Digipost.Api.Client.Tests/Smoke/ClientSmokeTests.cs
+++ b/Digipost.Api.Client.Tests/Smoke/ClientSmokeTests.cs
@@ -46,6 +46,16 @@ namespace Digipost.Api.Client.Tests.Smoke
                 .Expect_valid_sender_information();
         }
 
+
+        [Fact(Skip = "SmokeTest")]
+        public void Get_Document_events()
+        {
+            _client
+                .GetDocumentEvents()
+                .Expect_document_events();
+        }
+
+
         [Fact(Skip = "SmokeTest")]
         public void Can_send_document_digipost_user()
         {
@@ -75,6 +85,10 @@ namespace Digipost.Api.Client.Tests.Smoke
                 // Find a user with Tenor testdata to test registration. This is TYKKHUDET EKTEMANN
                 .SendRequestForRegistration("05926398190")
                 .Expect_message_to_have_method(DeliveryMethod.PENDING);
+
+            _client
+                .GetDocumentEvents()
+                .Expect_document_events();
         }
 
         [Fact(Skip = "SmokeTest")]

--- a/Digipost.Api.Client/Api/DocumentsApi.cs
+++ b/Digipost.Api.Client/Api/DocumentsApi.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Digipost.Api.Client.Common;
 using Digipost.Api.Client.Common.Entrypoint;
 using Digipost.Api.Client.Common.Utilities;
 using Digipost.Api.Client.Send;
@@ -15,6 +17,9 @@ namespace Digipost.Api.Client.Api
          */
         Task<DocumentStatus> GetDocumentStatus(Guid guid);
         Task<DocumentStatus> GetDocumentStatusAsync(Guid guid);
+
+        Task<DocumentEvents> GetDocumentEvents(DateTime from, DateTime to, int offset, int maxResults);
+        Task<DocumentEvents> GetDocumentEventsAsync(DateTime from, DateTime to, int offset, int maxResults);
     }
 
     internal class DocumentsApi : IDocumentsApi
@@ -22,12 +27,14 @@ namespace Digipost.Api.Client.Api
         private readonly RequestHelper _requestHelper;
         private readonly ILoggerFactory _loggerFactory;
         private readonly Root _root;
+        private readonly Sender _sender;
 
-        public DocumentsApi(RequestHelper requestHelper, ILoggerFactory loggerFactory, Root root)
+        public DocumentsApi(RequestHelper requestHelper, ILoggerFactory loggerFactory, Root root, Sender sender)
         {
             _requestHelper = requestHelper;
             _loggerFactory = loggerFactory;
             _root = root;
+            _sender = sender;
         }
 
         public Task<DocumentStatus> GetDocumentStatus(Guid guid)
@@ -44,6 +51,24 @@ namespace Digipost.Api.Client.Api
         {
             var documentStatusUri = _root.GetDocumentStatusUri(guid);
             var result = await _requestHelper.Get<Document_Status>(documentStatusUri).ConfigureAwait(false);
+
+            return result.FromDataTransferObject();
+        }
+
+        public Task<DocumentEvents> GetDocumentEvents(DateTime from, DateTime to, int offset, int maxResults)
+        {
+            var result = GetDocumentEventsAsync(from, to, offset, maxResults);
+
+            if (result.IsFaulted && result.Exception != null)
+                throw result.Exception.InnerException;
+
+            return result;
+        }
+
+        public async Task<DocumentEvents> GetDocumentEventsAsync(DateTime from, DateTime to, int offset, int maxResults)
+        {
+            var documentEventsUri = _root.GetDocumentEventsUri(_sender, from, to, offset, maxResults);
+            var result = await _requestHelper.Get<Document_Events>(documentEventsUri).ConfigureAwait(false);
 
             return result.FromDataTransferObject();
         }

--- a/Digipost.Api.Client/Api/SenderInformationApi.cs
+++ b/Digipost.Api.Client/Api/SenderInformationApi.cs
@@ -1,0 +1,45 @@
+using System;
+using Digipost.Api.Client.Common;
+using Digipost.Api.Client.Common.Exceptions;
+using Digipost.Api.Client.Common.Relations;
+using Digipost.Api.Client.Common.SenderInfo;
+using Digipost.Api.Client.Common.Utilities;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Digipost.Api.Client.Api
+{
+    internal class SenderInformationApi
+    {
+        private readonly IMemoryCache _entrypointCache;
+        private readonly RequestHelper _requestHelper;
+
+        internal SenderInformationApi(IMemoryCache entrypointCache, RequestHelper requestHelper)
+        {
+            _entrypointCache = entrypointCache;
+            _requestHelper = requestHelper;
+        }
+
+        public SenderInformation GetSenderInformation(SenderInformationUri senderInformationUri)
+        {
+            var cacheKey = "senderOrganisation" + senderInformationUri;
+
+            if (_entrypointCache.TryGetValue(cacheKey, out SenderInformation information)) return information;
+
+            var configuredTaskAwaitable = _requestHelper.Get<V8.Sender_Information>(senderInformationUri).ConfigureAwait(false);
+            var senderInformation = configuredTaskAwaitable.GetAwaiter().GetResult().FromDataTransferObject();
+
+            if (!senderInformation.IsValidSender)
+            {
+                throw new ConfigException($"Broker not authorized or sender does not exist. {senderInformation.SenderStatus}");
+            }
+
+            var cacheEntryOptions = new MemoryCacheEntryOptions()
+                // Keep in cache for 5 minutes when in use, but max 1 hour.
+                .SetAbsoluteExpiration(TimeSpan.FromHours(1))
+                .SetSlidingExpiration(TimeSpan.FromMinutes(5));
+
+            return _entrypointCache.Set(cacheKey, senderInformation, cacheEntryOptions);
+        }
+
+    }
+}

--- a/Digipost.Api.Client/DigipostClient.cs
+++ b/Digipost.Api.Client/DigipostClient.cs
@@ -102,28 +102,24 @@ namespace Digipost.Api.Client
             return _entrypointCache.Set(cacheKey, root, cacheEntryOptions);
         }
 
-        public SenderInformation GetSenderInformation(Sender senderId, SenderOrganisation senderOrganisation)
+        /// <summary>
+        /// Fetch Sender Information
+        /// </summary>
+        /// <param name="sender">The sender is optional. If not specified, the broker will be used.</param>
+        /// <returns></returns>
+        public SenderInformation GetSenderInformation(Sender sender = null)
         {
-            var senderInformationUri = GetRoot(new ApiRootUri(senderId)).GetSenderInformationUri(senderOrganisation.OrganisationNumber, senderOrganisation.PartId);
+            var senderToUse = sender ?? new Sender(_clientConfig.Broker.Id);
+            var senderInformationUri = GetRoot(new ApiRootUri()).GetSenderInformationUri(senderToUse);
 
-            var cacheKey = "senderOrganisation" + senderInformationUri;
+            return new SenderInformationApi(_entrypointCache, _requestHelper).GetSenderInformation(senderInformationUri);
+        }
 
-            if (_entrypointCache.TryGetValue(cacheKey, out SenderInformation information)) return information;
+        public SenderInformation GetSenderInformation(SenderOrganisation senderOrganisation)
+        {
+            var senderInformationUri = GetRoot(new ApiRootUri()).GetSenderInformationUri(senderOrganisation.OrganisationNumber, senderOrganisation.PartId);
 
-            var configuredTaskAwaitable = _requestHelper.Get<V8.Sender_Information>(senderInformationUri).ConfigureAwait(false);
-            var senderInformation = configuredTaskAwaitable.GetAwaiter().GetResult().FromDataTransferObject();
-
-            if (!senderInformation.IsValidSender)
-            {
-                throw new ConfigException($"Broker not authorized or sender does not exist. {senderInformation.SenderStatus}");
-            }
-
-            var cacheEntryOptions = new MemoryCacheEntryOptions()
-                // Keep in cache for 5 minutes when in use, but max 1 hour.
-                .SetAbsoluteExpiration(TimeSpan.FromHours(1))
-                .SetSlidingExpiration(TimeSpan.FromMinutes(5));
-
-            return _entrypointCache.Set(cacheKey, senderInformation, cacheEntryOptions);
+            return new SenderInformationApi(_entrypointCache, _requestHelper).GetSenderInformation(senderInformationUri);
         }
 
         public Inbox.Inbox GetInbox(Sender senderId)

--- a/Digipost.Api.Client/DigipostClient.cs
+++ b/Digipost.Api.Client/DigipostClient.cs
@@ -136,9 +136,15 @@ namespace Digipost.Api.Client
             return new Archive.ArchiveApi(_requestHelper, _loggerFactory, GetRoot(new ApiRootUri(senderId)));
         }
 
-        public IDocumentsApi GetDocumentStatus(Sender senderId = null)
+        /// <summary>
+        /// Get access to the document api.
+        /// </summary>
+        /// <param name="sender">Optional parameter for sender if you are a broker. If you don't specify a sender, your broker ident will be used</param>
+        /// <returns></returns>
+        public IDocumentsApi DocumentsApi(Sender sender = null)
         {
-            return new DocumentsApi(_requestHelper, _loggerFactory, GetRoot(new ApiRootUri(senderId)));
+            var senderToUse = sender ?? new Sender(_clientConfig.Broker.Id);
+            return new DocumentsApi(_requestHelper, _loggerFactory, GetRoot(new ApiRootUri(sender)), senderToUse);
         }
 
         public IIdentificationResult Identify(IIdentification identification)

--- a/docs/_v14_0/2_send_messages.md
+++ b/docs/_v14_0/2_send_messages.md
@@ -619,8 +619,9 @@ it is possible to send with organisation number and a partid. The partid can be 
 between different divisions or however the organisation sees fit. This makes it possible
 to not have to store the Digipost account id, but in stead fetch this information from the api.
 
+Fetch sender information based on orgnumber and partid.
 ```csharp
-var senderInformation = client.GetSenderInformation(sender, new SenderOrganisation("9876543210", "thePartId"));
+var senderInformation = client.GetSenderInformation(new SenderOrganisation("9876543210", "thePartId"));
 
 var message = new Message(
     senderInformation.Sender,

--- a/docs/_v14_0/2_send_messages.md
+++ b/docs/_v14_0/2_send_messages.md
@@ -167,7 +167,7 @@ var result = client.SendMessage(messageWithRequestForRegistration);
 If the sender wishes to send the document as physical mail through its own
 service, print details _must not be included_ but be `null` instead.
 
-````csharp
+```csharp
 var recipient = new RecipientById(identificationType: IdentificationType.PersonalIdentificationNumber, id: "311084xxxx");
 var documentGuid = Guid.NewGuid();
 
@@ -630,4 +630,47 @@ var message = new Message(
 
 var result = client.SendMessage(message);
 ```
-````
+
+### Get document events
+
+Document events is special events created by Digipost when certain events happens to a document
+that the broker/sender could use to perform other operations with regards to the processing of
+the document. 
+
+When a sender send a RequestForRegistration one might be interested in knowing IF the user
+has registered with in the timeout specified to for instance print the message or do som other
+processing. When the timeout is reached, Digipost will create a DocumentEvent 
+with type `RequestForRegistrationExpired`. This can then be fetched by the sender via DocumentEvent-api.
+
+This is done by polling in certain intervals defined by the sender. 
+
+The following code fetches at max 100 events last 5 minutes.
+```csharp
+var from = DateTime.Now.Subtract(TimeSpan.FromMinutes(5));
+var to = DateTime.Now;
+
+DocumentEvents events = await Client.DocumentsApi(Sender)
+                .GetDocumentEvents(from, to, offset: 0, maxResults: 100);
+
+IEnumerable<DocumentEventType> documentEventTypes = events.Select(aEvent => aEvent.EventType);
+```
+
+Please note that this does not mean that you return all events in the time interval, but the maxResult you ask for. This
+means that _if_ you get, say, 100 events in the list back, there is a possibility that there are more events in the 
+specified time interval. You then need to fetch the same interval again, but specify an offset according to you maxResult.
+
+Note that we here specify offset as 100 and use the same DateTime instance as used above. 
+```csharp
+DocumentEvents events = await Client.DocumentsApi(Sender)
+                .GetDocumentEvents(from: from, to: to, offset: 100, maxResults: 100);
+
+IEnumerable<DocumentEventType> documentEventTypes = events.Select(aEvent => aEvent.EventType);
+```
+
+Usually we want the you to pull as few events at a time that seems reasonable since you need to process the events 
+somehow while pulling more.
+
+When you receive 0 og less that the specified maxResults, you have received all events in the current time interval.
+
+We propose that you somehow store the state of the polling time interval. We expire/delete events after 90 days, so there
+are enough time to be sure you have processed them all. There is no way to delete an event through the api.


### PR DESCRIPTION
**Feature: Fetch Document events**

The feature is described in the documentation.


**Remove Sender as param to SetSenderInformation when org number and part id is used.**

There was a unforseen confusion in the implementation where the Sender
actually was you as a broker (the holder of the authentication to Digipost api).
It used the Sender class as a parameter to use as the broker. This is
not needed since we can scope the request to the broker.

So GetSenderInformation can be fetched for the broker (specify no sender),
for a Sender you broker for (specify a sender id) and organisation
you broker for (org number and part id)

![image](https://github.com/digipost/digipost-api-client-dotnet/assets/383121/a363670c-cbe6-4f8e-be17-ea02cbb64399)

