### PR TITLE
New document event: SHARE_DOCUMENTS_REQUEST_SHARING_WITHDRAWN

### DIFF
--- a/Digipost.Api.Client.Common/Enums/DocumentEventType.cs
+++ b/Digipost.Api.Client.Common/Enums/DocumentEventType.cs
@@ -17,5 +17,6 @@ namespace Digipost.Api.Client.Common.Enums
         RequestForRegistrationDeliveredDigipost,
         RequestForRegistrationFailed,
         ShareDocumentsRequestDocumentsShared,
+        ShareDocumentsRequestSharingWithdrawn,
     }
 }

--- a/Digipost.Api.Client.Common/Generated/Apidomain/V8.cs
+++ b/Digipost.Api.Client.Common/Generated/Apidomain/V8.cs
@@ -2496,6 +2496,9 @@ namespace Digipost.Api.Client.Common.Generated.V8
         
         [System.Xml.Serialization.XmlEnumAttribute("SHARE_DOCUMENTS_REQUEST_DOCUMENTS_SHARED")]
         ShareDocumentsRequestDocumentsShared,
+
+        [System.Xml.Serialization.XmlEnumAttribute("SHARE_DOCUMENTS_REQUEST_SHARING_WITHDRAWN")]
+        ShareDocumentsRequestSharingWithdrawn,
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("XmlSchemaClassGenerator", "2.1.963.0")]

--- a/Digipost.Api.Client.Resources/Xsd/Data/api_v8.xsd
+++ b/Digipost.Api.Client.Resources/Xsd/Data/api_v8.xsd
@@ -1119,6 +1119,7 @@
             <xsd:enumeration value="REQUEST_FOR_REGISTRATION_DELIVERED_DIGIPOST" />
             <xsd:enumeration value="REQUEST_FOR_REGISTRATION_FAILED" />
             <xsd:enumeration value="SHARE_DOCUMENTS_REQUEST_DOCUMENTS_SHARED"/>
+            <xsd:enumeration value="SHARE_DOCUMENTS_REQUEST_SHARING_WITHDRAWN"/>
         </xsd:restriction>
     </xsd:simpleType>
 


### PR DESCRIPTION
This event is generated whenever an active ShareDocumentsRequest is stopped or the sharing is withdrawn. The same event is generated in either case. This event is always generated for the Broker, not the Sender, so that Brokers may poll events for a number of different Senders using the same endpoint and parameters.