### PR TITLE
Date search - archive attributes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.x
     - name: Print openssl version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
       - name: Print openssl version

--- a/Digipost.Api.Client.Archive.Tests/ArchiveTest.cs
+++ b/Digipost.Api.Client.Archive.Tests/ArchiveTest.cs
@@ -28,7 +28,7 @@ namespace Digipost.Api.Client.Archive.Tests
             {
                 ["key"] = "val"
             };
-            Assert.Equal("https://www.testing.no/1010/archive/1000/document?limit=100&offset=0&attributes=a2V5LHZhbA==", archive.GetNextDocumentsUri(searchBy).ToString());
+            Assert.Equal("https://www.testing.no/1010/archive/1000/document?limit=100&offset=0&attributes=a2V5LHZhbA%3d%3d", archive.GetNextDocumentsUri(searchBy).ToString());
         }
     }
 }

--- a/Digipost.Api.Client.Archive.Tests/Digipost.Api.Client.Archive.Tests.csproj
+++ b/Digipost.Api.Client.Archive.Tests/Digipost.Api.Client.Archive.Tests.csproj
@@ -35,7 +35,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />

--- a/Digipost.Api.Client.Archive.Tests/Digipost.Api.Client.Archive.Tests.csproj
+++ b/Digipost.Api.Client.Archive.Tests/Digipost.Api.Client.Archive.Tests.csproj
@@ -34,8 +34,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />

--- a/Digipost.Api.Client.Archive.Tests/Smoke/ArchiveSmokeTests.cs
+++ b/Digipost.Api.Client.Archive.Tests/Smoke/ArchiveSmokeTests.cs
@@ -1,4 +1,6 @@
-﻿using Digipost.Api.Client.Tests.Utilities;
+﻿using System;
+using System.Collections.Generic;
+using Digipost.Api.Client.Tests.Utilities;
 using Xunit;
 
 namespace Digipost.Api.Client.Archive.Tests.Smoke
@@ -26,10 +28,20 @@ namespace Digipost.Api.Client.Archive.Tests.Smoke
         [Fact(Skip = "SmokeTest")]
         public void ArchiveADocumentWithAttributes()
         {
+            var from = DateTime.Now;
+            
+            var searchBy = new Dictionary<string, string>
+            {
+                ["smoke"] = "test"
+            };
+            
             _t.ArchiveAFile()
                 .Get_Default_Archive()
                 .Get_All_DocumentsWithAttributes()
-                .Update_attritbutesOnFirst();
+                .Update_attritbutesOnFirst()
+                .Get_For_Timeinterval(from, DateTime.Now, 1)
+                .Get_For_TimeintervalWithAttributes(searchBy, from, DateTime.Now, 1);
+
         }
     }
 }

--- a/Digipost.Api.Client.Archive.Tests/Smoke/ArchiveSmokeTestsHelper.cs
+++ b/Digipost.Api.Client.Archive.Tests/Smoke/ArchiveSmokeTestsHelper.cs
@@ -57,7 +57,7 @@ ___/ / /  / / /_/ / /| |/ /___  / / / /___ ___/ // /
 
         public ArchiveSmokeTestsHelper Get_Default_Archive()
         {
-            _archive = _archiveApi.FetchArchives().Result.Where(a => a.Name == null).First();
+            _archive = _archiveApi.FetchArchives().Result.First(a => a.Name == string.Empty);
             return this;
         }
 
@@ -83,6 +83,24 @@ ___/ / /  / / /_/ / /| |/ /___  / / / /___ ___/ // /
             _byAttribute = _archiveApi.FetchArchiveDocuments(_archive.GetNextDocumentsUri(searchBy)).Result;
 
             Assert.NotEmpty(_byAttribute.ArchiveDocuments);
+            return this;
+        }
+
+        public ArchiveSmokeTestsHelper Get_For_Timeinterval(DateTime start, DateTime end, int expectCount = 0)
+        {
+            _byAttribute = _archiveApi.FetchArchiveDocuments(_archive.GetNextDocumentsUri(start, end)).Result;
+            
+            Assert.Equal(expectCount, _byAttribute.ArchiveDocuments.Count);
+            
+            return this;
+        }
+
+        public ArchiveSmokeTestsHelper Get_For_TimeintervalWithAttributes(Dictionary<string, string> searchBy, DateTime start, DateTime end, int expectCount = 0)
+        {
+            _byAttribute = _archiveApi.FetchArchiveDocuments(_archive.GetNextDocumentsUri(searchBy, start, end)).Result;
+            
+            Assert.Equal(expectCount, _byAttribute.ArchiveDocuments.Count);
+            
             return this;
         }
 

--- a/Digipost.Api.Client.Archive/Archive.cs
+++ b/Digipost.Api.Client.Archive/Archive.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Digipost.Api.Client.Common;
 using Digipost.Api.Client.Common.Relations;
@@ -65,6 +66,16 @@ namespace Digipost.Api.Client.Archive
         public ArchiveNextDocumentsUri GetNextDocumentsUri(Dictionary<string, string> searchBy)
         {
             return new ArchiveNextDocumentsUri(Links["NEXT_DOCUMENTS"], searchBy);
+        }
+
+        public ArchiveNextDocumentsUri GetNextDocumentsUri(DateTime from, DateTime to)
+        {
+            return new ArchiveNextDocumentsUri(Links["NEXT_DOCUMENTS"], from, to);
+        }
+
+        public ArchiveNextDocumentsUri GetNextDocumentsUri(Dictionary<string,string> searchBy, DateTime from, DateTime to)
+        {
+            return new ArchiveNextDocumentsUri(Links["NEXT_DOCUMENTS"], searchBy, from, to);
         }
     }
 }

--- a/Digipost.Api.Client.Archive/Digipost.Api.Client.Archive.csproj
+++ b/Digipost.Api.Client.Archive/Digipost.Api.Client.Archive.csproj
@@ -39,8 +39,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">
             <Project>{CD338E5A-1ED0-4331-B34E-8292FA8E387B}</Project>
             <Name>Digipost.Api.Client.Common</Name>

--- a/Digipost.Api.Client.Archive/Digipost.Api.Client.Archive.csproj
+++ b/Digipost.Api.Client.Archive/Digipost.Api.Client.Archive.csproj
@@ -40,7 +40,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">
             <Project>{CD338E5A-1ED0-4331-B34E-8292FA8E387B}</Project>

--- a/Digipost.Api.Client.Common.Tests/Digipost.Api.Client.Common.Tests.csproj
+++ b/Digipost.Api.Client.Common.Tests/Digipost.Api.Client.Common.Tests.csproj
@@ -35,7 +35,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />

--- a/Digipost.Api.Client.Common.Tests/Digipost.Api.Client.Common.Tests.csproj
+++ b/Digipost.Api.Client.Common.Tests/Digipost.Api.Client.Common.Tests.csproj
@@ -34,8 +34,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />

--- a/Digipost.Api.Client.Common.Tests/Relations/ApiRelationsTests.cs
+++ b/Digipost.Api.Client.Common.Tests/Relations/ApiRelationsTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using Digipost.Api.Client.Common.Enums;
+using Digipost.Api.Client.Common.Relations;
+using Digipost.Api.Client.Common.Utilities;
+using Xunit;
+
+namespace Digipost.Api.Client.Common.Tests.Utilities
+{
+    public class ApiRelationsTests
+    {
+        private static readonly Uri BaseUri = new Uri("https://api.io/api/archive/search?id=123");
+
+        [Fact]
+        public void should_produce_archive_search_url_query()
+        {
+            Assert.Equal("https://api.io:443/api/archive/search?id=123",
+                ArchiveNextDocumentsUri.ToUri(BaseUri, new Dictionary<string, string>(), null, null));
+
+            Assert.Equal("https://api.io:443/api/archive/search?id=123&attributes=aWQsMTIz",
+                ArchiveNextDocumentsUri.ToUri(BaseUri, new Dictionary<string, string>()
+                    {
+                        ["id"] = "123",
+                    },
+                    null, null
+                ));
+
+            var url = ArchiveNextDocumentsUri.ToUri(BaseUri, new Dictionary<string, string>(),
+                DateTime.Parse("2024-10-26 14:50:14Z"),
+                DateTime.Parse("2024-10-28 14:50:14Z")
+            );
+            Assert.Contains("fromDate=2024-10-26T", url);
+            Assert.Contains("toDate=2024-10-28T", url);
+        }
+    }
+}

--- a/Digipost.Api.Client.Common/Digipost.Api.Client.Common.csproj
+++ b/Digipost.Api.Client.Common/Digipost.Api.Client.Common.csproj
@@ -40,7 +40,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />

--- a/Digipost.Api.Client.Common/Digipost.Api.Client.Common.csproj
+++ b/Digipost.Api.Client.Common/Digipost.Api.Client.Common.csproj
@@ -39,8 +39,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.3" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />

--- a/Digipost.Api.Client.Common/Relations/ApiRelations.cs
+++ b/Digipost.Api.Client.Common/Relations/ApiRelations.cs
@@ -71,7 +71,6 @@ namespace Digipost.Api.Client.Common.Relations
         public AddAdditionalDataUri(Link link)
             : base(link.Uri, UriKind.Absolute)
         {
-
         }
     }
 
@@ -144,20 +143,41 @@ namespace Digipost.Api.Client.Common.Relations
         }
 
         public ArchiveNextDocumentsUri(Link link, Dictionary<string, string> searchBy)
-            : base(ToUri(new Uri(link.Uri, UriKind.Absolute), searchBy), UriKind.Absolute)
+            : base(ToUri(new Uri(link.Uri, UriKind.Absolute), searchBy, null, null), UriKind.Absolute)
         {
         }
 
-        private static string ToUri(Uri nextDocumentsUri, Dictionary<string, string> searchBy)
+        public ArchiveNextDocumentsUri(Link link, DateTime from, DateTime to)
+            : base(ToUri(new Uri(link.Uri, UriKind.Absolute), new Dictionary<string, string>(), from, to), UriKind.Absolute)
+        {
+        }
+
+        public ArchiveNextDocumentsUri(Link link, Dictionary<string, string> searchBy, DateTime from, DateTime to)
+            : base(ToUri(new Uri(link.Uri, UriKind.Absolute), searchBy, from, to), UriKind.Absolute)
+        {
+            
+        }
+
+        internal static string ToUri(Uri nextDocumentsUri, Dictionary<string, string> searchBy, DateTime? from, DateTime? to)
         {
             var query = HttpUtility.ParseQueryString(nextDocumentsUri.Query);
-            var commaSeparated = string.Join(",", searchBy.Select(x => x.Key + "," + x.Value).ToArray());
-            var base64 = ToBase64String(Encoding.UTF8.GetBytes(commaSeparated));
+            if (searchBy.Count > 0)
+            {
+                var commaSeparated = string.Join(",", searchBy.Select(x => x.Key + "," + x.Value).ToArray());
+                var base64 = ToBase64String(Encoding.UTF8.GetBytes(commaSeparated));
 
-            query["attributes"] = "";
+                query["attributes"] = base64;
+            }
+
+            if (from != null && to != null)
+            {
+                query["fromDate"] = from.Value.ToString("o");
+                query["toDate"] = to.Value.ToString("o");
+            }
+
             var uriBuilder = new UriBuilder(nextDocumentsUri)
             {
-                Query = query + base64
+                Query = query.ToString()
             };
             return uriBuilder.ToString();
         }
@@ -200,7 +220,6 @@ namespace Digipost.Api.Client.Common.Relations
         public DocumentEventsUri(Link link, Sender sender, DateTime from, DateTime to, int offset, int maxResults)
             : base($"{link.Uri}?sender={sender.Id}&from={DatetimeFormatter(from)}&to={DatetimeFormatter(to)}&offset={offset}&maxResults={maxResults}", UriKind.Absolute)
         {
-
         }
 
         private static string DatetimeFormatter(DateTime? dt)

--- a/Digipost.Api.Client.ConcurrencyTest/Digipost.Api.Client.ConcurrencyTest.csproj
+++ b/Digipost.Api.Client.ConcurrencyTest/Digipost.Api.Client.ConcurrencyTest.csproj
@@ -33,8 +33,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">

--- a/Digipost.Api.Client.ConcurrencyTest/Digipost.Api.Client.ConcurrencyTest.csproj
+++ b/Digipost.Api.Client.ConcurrencyTest/Digipost.Api.Client.ConcurrencyTest.csproj
@@ -34,7 +34,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Digipost.Api.Client.Docs/Digipost.Api.Client.Docs.csproj
+++ b/Digipost.Api.Client.Docs/Digipost.Api.Client.Docs.csproj
@@ -37,8 +37,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">
             <Project>{CD338E5A-1ED0-4331-B34E-8292FA8E387B}</Project>
             <Name>Digipost.Api.Client.Common</Name>

--- a/Digipost.Api.Client.Docs/Digipost.Api.Client.Docs.csproj
+++ b/Digipost.Api.Client.Docs/Digipost.Api.Client.Docs.csproj
@@ -38,7 +38,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">
             <Project>{CD338E5A-1ED0-4331-B34E-8292FA8E387B}</Project>

--- a/Digipost.Api.Client.Inbox.Tests/Digipost.Api.Client.Inbox.Tests.csproj
+++ b/Digipost.Api.Client.Inbox.Tests/Digipost.Api.Client.Inbox.Tests.csproj
@@ -35,7 +35,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />

--- a/Digipost.Api.Client.Inbox.Tests/Digipost.Api.Client.Inbox.Tests.csproj
+++ b/Digipost.Api.Client.Inbox.Tests/Digipost.Api.Client.Inbox.Tests.csproj
@@ -34,8 +34,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />

--- a/Digipost.Api.Client.Inbox/Digipost.Api.Client.Inbox.csproj
+++ b/Digipost.Api.Client.Inbox/Digipost.Api.Client.Inbox.csproj
@@ -39,8 +39,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">
             <Project>{CD338E5A-1ED0-4331-B34E-8292FA8E387B}</Project>
             <Name>Digipost.Api.Client.Common</Name>

--- a/Digipost.Api.Client.Inbox/Digipost.Api.Client.Inbox.csproj
+++ b/Digipost.Api.Client.Inbox/Digipost.Api.Client.Inbox.csproj
@@ -40,7 +40,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">
             <Project>{CD338E5A-1ED0-4331-B34E-8292FA8E387B}</Project>

--- a/Digipost.Api.Client.Resources/Digipost.Api.Client.Resources.csproj
+++ b/Digipost.Api.Client.Resources/Digipost.Api.Client.Resources.csproj
@@ -40,7 +40,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
     </ItemGroup>
 

--- a/Digipost.Api.Client.Resources/Digipost.Api.Client.Resources.csproj
+++ b/Digipost.Api.Client.Resources/Digipost.Api.Client.Resources.csproj
@@ -39,8 +39,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Digipost.Api.Client.Send.Tests/Digipost.Api.Client.Send.Tests.csproj
+++ b/Digipost.Api.Client.Send.Tests/Digipost.Api.Client.Send.Tests.csproj
@@ -35,7 +35,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />

--- a/Digipost.Api.Client.Send.Tests/Digipost.Api.Client.Send.Tests.csproj
+++ b/Digipost.Api.Client.Send.Tests/Digipost.Api.Client.Send.Tests.csproj
@@ -34,8 +34,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />

--- a/Digipost.Api.Client.Send/Digipost.Api.Client.Send.csproj
+++ b/Digipost.Api.Client.Send/Digipost.Api.Client.Send.csproj
@@ -40,7 +40,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.DataTypes.Core" Version="4.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">

--- a/Digipost.Api.Client.Send/Digipost.Api.Client.Send.csproj
+++ b/Digipost.Api.Client.Send/Digipost.Api.Client.Send.csproj
@@ -39,9 +39,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.DataTypes.Core" Version="4.0.0" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.DataTypes.Core" Version="4.2.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <ProjectReference Include="..\Digipost.Api.Client.Common\Digipost.Api.Client.Common.csproj">
             <Project>{CD338E5A-1ED0-4331-B34E-8292FA8E387B}</Project>
             <Name>Digipost.Api.Client.Common</Name>

--- a/Digipost.Api.Client.Tests/Digipost.Api.Client.Tests.csproj
+++ b/Digipost.Api.Client.Tests/Digipost.Api.Client.Tests.csproj
@@ -34,9 +34,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
         <PackageReference Include="CompareNETObjects" Version="4.66.0" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />

--- a/Digipost.Api.Client.Tests/Digipost.Api.Client.Tests.csproj
+++ b/Digipost.Api.Client.Tests/Digipost.Api.Client.Tests.csproj
@@ -36,7 +36,6 @@
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
         <PackageReference Include="CompareNETObjects" Version="4.66.0" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit.abstractions" Version="2.0.3" />

--- a/Digipost.Api.Client/Digipost.Api.Client.csproj
+++ b/Digipost.Api.Client/Digipost.Api.Client.csproj
@@ -41,7 +41,6 @@
 
     <ItemGroup>
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Difi.Felles.Utility" Version="5.0.0" />
         <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />

--- a/Digipost.Api.Client/Digipost.Api.Client.csproj
+++ b/Digipost.Api.Client/Digipost.Api.Client.csproj
@@ -40,8 +40,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
-        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.3" />
+        <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+        <PackageReference Include="Digipost.Api.Client.Shared" Version="7.1.5" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />


### PR DESCRIPTION
GetNextDocumentsUri will now accept from- and to-date to search for
documents archived between the given point in time.
The api will page as normal on limit-size.